### PR TITLE
remove elevator= kernel parameter for rhel8

### DIFF
--- a/http/generic.rhel8.vagrant.ks
+++ b/http/generic.rhel8.vagrant.ks
@@ -16,7 +16,7 @@ network --device eth0 --bootproto dhcp --noipv6 --hostname=rhel8.localdomain
 
 zerombr
 clearpart --all --initlabel
-bootloader --location=mbr --append="net.ifnames=0 biosdevname=0 elevator=noop no_timer_check"
+bootloader --location=mbr --append="net.ifnames=0 biosdevname=0 no_timer_check"
 autopart
 
 rootpw vagrant


### PR DESCRIPTION
RedHat deprecated support for elevator= kernel parameter
https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/8.0_release_notes/deprecated_functionality