### PR TITLE
Allow SSH TCP port forwarding on newer Alpine boxes.

### DIFF
--- a/scripts/alpine310/sshd.sh
+++ b/scripts/alpine310/sshd.sh
@@ -5,3 +5,6 @@ sed -i "/^#UseDNS.*/d" /etc/ssh/sshd_config
 sed -i "/^# UseDNS.*/d" /etc/ssh/sshd_config
 
 printf "\nUseDNS no\n" >> /etc/ssh/sshd_config
+
+sed -i '/AllowTcpForwarding/d' /etc/ssh/sshd_config
+printf "\nAllowTcpForwarding yes\n" >> /etc/ssh/sshd_config

--- a/scripts/alpine39/sshd.sh
+++ b/scripts/alpine39/sshd.sh
@@ -5,3 +5,6 @@ sed -i "/^#UseDNS.*/d" /etc/ssh/sshd_config
 sed -i "/^# UseDNS.*/d" /etc/ssh/sshd_config
 
 printf "\nUseDNS no\n" >> /etc/ssh/sshd_config
+
+sed -i '/AllowTcpForwarding/d' /etc/ssh/sshd_config
+printf "\nAllowTcpForwarding yes\n" >> /etc/ssh/sshd_config


### PR DESCRIPTION
Especially libvirt guests need this, since it's their main way of sharing ports with the host.

This has been allowed previously as well, but the default changed to "no" with Alpine 3.9.