### PR TITLE
alpine: Don't use the :alt workaround if :alpine is available

### DIFF
--- a/tpl/generic-alpine310.rb
+++ b/tpl/generic-alpine310.rb
@@ -32,7 +32,12 @@ Vagrant.configure(2) do |config|
     v.memory = 2048
     v.driver = "kvm"
     v.video_vram = 256
-    override.vm.guest = :alt
+    if Vagrant::VERSION < '2.2.6' && !Vagrant.has_plugin?("vagrant-alpine")
+      override.trigger.before :up do |t|
+        t.warn = "Setting OS type to 'ALT Linux' as a workaround, which might break guest OS specific features.\nPlease upgrade to Vagrant 2.2.6 or (if Vagrant can't be upgraded) install the 'vagrant-alpine' plugin if issues arise."
+      end
+      override.vm.guest = :alt
+    end
     v.channel :type => 'unix', :target_name => 'org.qemu.guest_agent.0', :target_type => 'virtio'
   end
 

--- a/tpl/generic-alpine35.rb
+++ b/tpl/generic-alpine35.rb
@@ -32,7 +32,12 @@ Vagrant.configure(2) do |config|
     v.memory = 2048
     v.driver = "kvm"
     v.video_vram = 256
-    override.vm.guest = :alt
+    if Vagrant::VERSION < '2.2.6' && !Vagrant.has_plugin?("vagrant-alpine")
+      override.trigger.before :up do |t|
+        t.warn = "Setting OS type to 'ALT Linux' as a workaround, which might break guest OS specific features.\nPlease upgrade to Vagrant 2.2.6 or (if Vagrant can't be upgraded) install the 'vagrant-alpine' plugin if issues arise."
+      end
+      override.vm.guest = :alt
+    end
     v.channel :type => 'unix', :target_name => 'org.qemu.guest_agent.0', :target_type => 'virtio'
   end
 

--- a/tpl/generic-alpine36.rb
+++ b/tpl/generic-alpine36.rb
@@ -32,7 +32,12 @@ Vagrant.configure(2) do |config|
     v.memory = 2048
     v.driver = "kvm"
     v.video_vram = 256
-    override.vm.guest = :alt
+    if Vagrant::VERSION < '2.2.6' && !Vagrant.has_plugin?("vagrant-alpine")
+      override.trigger.before :up do |t|
+        t.warn = "Setting OS type to 'ALT Linux' as a workaround, which might break guest OS specific features.\nPlease upgrade to Vagrant 2.2.6 or (if Vagrant can't be upgraded) install the 'vagrant-alpine' plugin if issues arise."
+      end
+      override.vm.guest = :alt
+    end
     v.channel :type => 'unix', :target_name => 'org.qemu.guest_agent.0', :target_type => 'virtio'
   end
 

--- a/tpl/generic-alpine37.rb
+++ b/tpl/generic-alpine37.rb
@@ -32,7 +32,12 @@ Vagrant.configure(2) do |config|
     v.memory = 2048
     v.driver = "kvm"
     v.video_vram = 256
-    override.vm.guest = :alt
+    if Vagrant::VERSION < '2.2.6' && !Vagrant.has_plugin?("vagrant-alpine")
+      override.trigger.before :up do |t|
+        t.warn = "Setting OS type to 'ALT Linux' as a workaround, which might break guest OS specific features.\nPlease upgrade to Vagrant 2.2.6 or (if Vagrant can't be upgraded) install the 'vagrant-alpine' plugin if issues arise."
+      end
+      override.vm.guest = :alt
+    end
     v.channel :type => 'unix', :target_name => 'org.qemu.guest_agent.0', :target_type => 'virtio'
   end
 

--- a/tpl/generic-alpine38.rb
+++ b/tpl/generic-alpine38.rb
@@ -32,7 +32,12 @@ Vagrant.configure(2) do |config|
     v.memory = 2048
     v.driver = "kvm"
     v.video_vram = 256
-    override.vm.guest = :alt
+    if Vagrant::VERSION < '2.2.6' && !Vagrant.has_plugin?("vagrant-alpine")
+      override.trigger.before :up do |t|
+        t.warn = "Setting OS type to 'ALT Linux' as a workaround, which might break guest OS specific features.\nPlease upgrade to Vagrant 2.2.6 or (if Vagrant can't be upgraded) install the 'vagrant-alpine' plugin if issues arise."
+      end
+      override.vm.guest = :alt
+    end
     v.channel :type => 'unix', :target_name => 'org.qemu.guest_agent.0', :target_type => 'virtio'
   end
 

--- a/tpl/generic-alpine39.rb
+++ b/tpl/generic-alpine39.rb
@@ -32,7 +32,12 @@ Vagrant.configure(2) do |config|
     v.memory = 2048
     v.driver = "kvm"
     v.video_vram = 256
-    override.vm.guest = :alt
+    if Vagrant::VERSION < '2.2.6' && !Vagrant.has_plugin?("vagrant-alpine")
+      override.trigger.before :up do |t|
+        t.warn = "Setting OS type to 'ALT Linux' as a workaround, which might break guest OS specific features.\nPlease upgrade to Vagrant 2.2.6 or (if Vagrant can't be upgraded) install the 'vagrant-alpine' plugin if issues arise."
+      end
+      override.vm.guest = :alt
+    end
     v.channel :type => 'unix', :target_name => 'org.qemu.guest_agent.0', :target_type => 'virtio'
   end
 

--- a/tpl/magma-alpine.rb
+++ b/tpl/magma-alpine.rb
@@ -106,7 +106,12 @@ Vagrant.configure(2) do |config|
     v.memory = 2048
     v.driver = "kvm"
     v.video_vram = 256
-    override.vm.guest = :alt
+    if Vagrant::VERSION < '2.2.6' && !Vagrant.has_plugin?("vagrant-alpine")
+      override.trigger.before :up do |t|
+        t.warn = "Setting OS type to 'ALT Linux' as a workaround, which might break guest OS specific features.\nPlease upgrade to Vagrant 2.2.6 or (if Vagrant can't be upgraded) install the 'vagrant-alpine' plugin if issues arise."
+      end
+      override.vm.guest = :alt
+    end
     v.channel :type => 'unix', :target_name => 'org.qemu.guest_agent.0', :target_type => 'virtio'
   end
 

--- a/tpl/roboxes-alpine310.rb
+++ b/tpl/roboxes-alpine310.rb
@@ -32,7 +32,12 @@ Vagrant.configure(2) do |config|
     v.memory = 2048
     v.driver = "kvm"
     v.video_vram = 256
-    override.vm.guest = :alt
+    if Vagrant::VERSION < '2.2.6' && !Vagrant.has_plugin?("vagrant-alpine")
+      override.trigger.before :up do |t|
+        t.warn = "Setting OS type to 'ALT Linux' as a workaround, which might break guest OS specific features.\nPlease upgrade to Vagrant 2.2.6 or (if Vagrant can't be upgraded) install the 'vagrant-alpine' plugin if issues arise."
+      end
+      override.vm.guest = :alt
+    end
     v.channel :type => 'unix', :target_name => 'org.qemu.guest_agent.0', :target_type => 'virtio'
   end
 

--- a/tpl/roboxes-alpine35.rb
+++ b/tpl/roboxes-alpine35.rb
@@ -32,7 +32,12 @@ Vagrant.configure(2) do |config|
     v.memory = 2048
     v.driver = "kvm"
     v.video_vram = 256
-    override.vm.guest = :alt
+    if Vagrant::VERSION < '2.2.6' && !Vagrant.has_plugin?("vagrant-alpine")
+      override.trigger.before :up do |t|
+        t.warn = "Setting OS type to 'ALT Linux' as a workaround, which might break guest OS specific features.\nPlease upgrade to Vagrant 2.2.6 or (if Vagrant can't be upgraded) install the 'vagrant-alpine' plugin if issues arise."
+      end
+      override.vm.guest = :alt
+    end
     v.channel :type => 'unix', :target_name => 'org.qemu.guest_agent.0', :target_type => 'virtio'
   end
 

--- a/tpl/roboxes-alpine36.rb
+++ b/tpl/roboxes-alpine36.rb
@@ -32,7 +32,12 @@ Vagrant.configure(2) do |config|
     v.memory = 2048
     v.driver = "kvm"
     v.video_vram = 256
-    override.vm.guest = :alt
+    if Vagrant::VERSION < '2.2.6' && !Vagrant.has_plugin?("vagrant-alpine")
+      override.trigger.before :up do |t|
+        t.warn = "Setting OS type to 'ALT Linux' as a workaround, which might break guest OS specific features.\nPlease upgrade to Vagrant 2.2.6 or (if Vagrant can't be upgraded) install the 'vagrant-alpine' plugin if issues arise."
+      end
+      override.vm.guest = :alt
+    end
     v.channel :type => 'unix', :target_name => 'org.qemu.guest_agent.0', :target_type => 'virtio'
   end
 

--- a/tpl/roboxes-alpine37.rb
+++ b/tpl/roboxes-alpine37.rb
@@ -32,7 +32,12 @@ Vagrant.configure(2) do |config|
     v.memory = 2048
     v.driver = "kvm"
     v.video_vram = 256
-    override.vm.guest = :alt
+    if Vagrant::VERSION < '2.2.6' && !Vagrant.has_plugin?("vagrant-alpine")
+      override.trigger.before :up do |t|
+        t.warn = "Setting OS type to 'ALT Linux' as a workaround, which might break guest OS specific features.\nPlease upgrade to Vagrant 2.2.6 or (if Vagrant can't be upgraded) install the 'vagrant-alpine' plugin if issues arise."
+      end
+      override.vm.guest = :alt
+    end
     v.channel :type => 'unix', :target_name => 'org.qemu.guest_agent.0', :target_type => 'virtio'
   end
 

--- a/tpl/roboxes-alpine38.rb
+++ b/tpl/roboxes-alpine38.rb
@@ -32,7 +32,12 @@ Vagrant.configure(2) do |config|
     v.memory = 2048
     v.driver = "kvm"
     v.video_vram = 256
-    override.vm.guest = :alt
+    if Vagrant::VERSION < '2.2.6' && !Vagrant.has_plugin?("vagrant-alpine")
+      override.trigger.before :up do |t|
+        t.warn = "Setting OS type to 'ALT Linux' as a workaround, which might break guest OS specific features.\nPlease upgrade to Vagrant 2.2.6 or (if Vagrant can't be upgraded) install the 'vagrant-alpine' plugin if issues arise."
+      end
+      override.vm.guest = :alt
+    end
     v.channel :type => 'unix', :target_name => 'org.qemu.guest_agent.0', :target_type => 'virtio'
   end
 

--- a/tpl/roboxes-alpine39.rb
+++ b/tpl/roboxes-alpine39.rb
@@ -32,7 +32,12 @@ Vagrant.configure(2) do |config|
     v.memory = 2048
     v.driver = "kvm"
     v.video_vram = 256
-    override.vm.guest = :alt
+    if Vagrant::VERSION < '2.2.6' && !Vagrant.has_plugin?("vagrant-alpine")
+      override.trigger.before :up do |t|
+        t.warn = "Setting OS type to 'ALT Linux' as a workaround, which might break guest OS specific features.\nPlease upgrade to Vagrant 2.2.6 or (if Vagrant can't be upgraded) install the 'vagrant-alpine' plugin if issues arise."
+      end
+      override.vm.guest = :alt
+    end
     v.channel :type => 'unix', :target_name => 'org.qemu.guest_agent.0', :target_type => 'virtio'
   end
 


### PR DESCRIPTION
As already discussed in hashicorp/vagrant#10975

Should be blocked until Vagrant 2.2.6 releases.