### PR TITLE
Use UTF-8 locale on Debian and Ubuntu

### DIFF
--- a/http/generic.debian10.vagrant.cfg
+++ b/http/generic.debian10.vagrant.cfg
@@ -2,7 +2,7 @@ choose-mirror-bin mirror/http/proxy string
 d-i base-installer/kernel/override-image string linux-server
 d-i keyboard-configuration/xkb-keymap select us
 d-i time/zone string US/Pacific
-d-i debian-installer/locale string en_US
+d-i debian-installer/locale string en_US.UTF-8
 d-i debian-installer/add-kernel-opts string net.ifnames=0 biosdevname=0
 d-i finish-install/reboot_in_progress note
 d-i grub-installer/bootdev string default

--- a/http/generic.debian8.vagrant.cfg
+++ b/http/generic.debian8.vagrant.cfg
@@ -7,7 +7,7 @@ d-i mirror/http/directory string /debian
 d-i base-installer/kernel/override-image string linux-server
 d-i keyboard-configuration/xkb-keymap select us
 d-i time/zone string US/Pacific
-d-i debian-installer/locale string en_US
+d-i debian-installer/locale string en_US.UTF-8
 d-i debian-installer/add-kernel-opts string net.ifnames=0 biosdevname=0 
 d-i finish-install/reboot_in_progress note
 d-i grub-installer/bootdev string default

--- a/http/generic.debian9.vagrant.cfg
+++ b/http/generic.debian9.vagrant.cfg
@@ -2,7 +2,7 @@ choose-mirror-bin mirror/http/proxy string
 d-i base-installer/kernel/override-image string linux-server
 d-i keyboard-configuration/xkb-keymap select us
 d-i time/zone string US/Pacific
-d-i debian-installer/locale string en_US
+d-i debian-installer/locale string en_US.UTF-8
 d-i debian-installer/add-kernel-opts string net.ifnames=0 biosdevname=0 
 d-i finish-install/reboot_in_progress note
 d-i grub-installer/bootdev string default

--- a/http/generic.ubuntu1604.vagrant.cfg
+++ b/http/generic.ubuntu1604.vagrant.cfg
@@ -1,7 +1,7 @@
 d-i base-installer/kernel/override-image string linux-server
 d-i keyboard-configuration/xkb-keymap select us
 d-i time/zone string US/Pacific
-d-i debian-installer/locale string en_US
+d-i debian-installer/locale string en_US.UTF-8
 d-i debian-installer/add-kernel-opts string net.ifnames=0 biosdevname=0 
 d-i finish-install/reboot_in_progress note
 d-i grub-installer/bootdev string default

--- a/http/generic.ubuntu1610.vagrant.cfg
+++ b/http/generic.ubuntu1610.vagrant.cfg
@@ -1,7 +1,7 @@
 d-i base-installer/kernel/override-image string linux-server
 d-i keyboard-configuration/xkb-keymap select us
 d-i time/zone string US/Pacific
-d-i debian-installer/locale string en_US
+d-i debian-installer/locale string en_US.UTF-8
 d-i debian-installer/add-kernel-opts string net.ifnames=0 biosdevname=0 
 d-i finish-install/reboot_in_progress note
 d-i grub-installer/bootdev string default

--- a/http/generic.ubuntu1704.vagrant.cfg
+++ b/http/generic.ubuntu1704.vagrant.cfg
@@ -1,7 +1,7 @@
 d-i base-installer/kernel/override-image string linux-server
 d-i keyboard-configuration/xkb-keymap select us
 d-i time/zone string US/Pacific
-d-i debian-installer/locale string en_US
+d-i debian-installer/locale string en_US.UTF-8
 d-i debian-installer/add-kernel-opts string net.ifnames=0 biosdevname=0 
 d-i finish-install/reboot_in_progress note
 d-i grub-installer/bootdev string default

--- a/http/generic.ubuntu1710.vagrant.cfg
+++ b/http/generic.ubuntu1710.vagrant.cfg
@@ -1,7 +1,7 @@
 d-i base-installer/kernel/override-image string linux-server
 d-i keyboard-configuration/xkb-keymap select us
 d-i time/zone string US/Pacific
-d-i debian-installer/locale string en_US
+d-i debian-installer/locale string en_US.UTF-8
 d-i debian-installer/add-kernel-opts string net.ifnames=0 biosdevname=0
 d-i finish-install/reboot_in_progress note
 d-i grub-installer/bootdev string default

--- a/http/generic.ubuntu1804.vagrant.cfg
+++ b/http/generic.ubuntu1804.vagrant.cfg
@@ -1,7 +1,7 @@
 d-i base-installer/kernel/override-image string linux-server
 d-i keyboard-configuration/xkb-keymap select us
 d-i time/zone string US/Pacific
-d-i debian-installer/locale string en_US
+d-i debian-installer/locale string en_US.UTF-8
 d-i debian-installer/add-kernel-opts string net.ifnames=0 biosdevname=0
 d-i finish-install/reboot_in_progress note
 d-i grub-installer/bootdev string default

--- a/http/generic.ubuntu1810.vagrant.cfg
+++ b/http/generic.ubuntu1810.vagrant.cfg
@@ -1,7 +1,7 @@
 d-i base-installer/kernel/override-image string linux-server
 d-i keyboard-configuration/xkb-keymap select us
 d-i time/zone string US/Pacific
-d-i debian-installer/locale string en_US
+d-i debian-installer/locale string en_US.UTF-8
 d-i debian-installer/add-kernel-opts string net.ifnames=0 biosdevname=0
 d-i finish-install/reboot_in_progress note
 d-i grub-installer/bootdev string default

--- a/http/generic.ubuntu1904.vagrant.cfg
+++ b/http/generic.ubuntu1904.vagrant.cfg
@@ -1,7 +1,7 @@
 d-i base-installer/kernel/override-image string linux-server
 d-i keyboard-configuration/xkb-keymap select us
 d-i time/zone string US/Pacific
-d-i debian-installer/locale string en_US
+d-i debian-installer/locale string en_US.UTF-8
 d-i debian-installer/add-kernel-opts string net.ifnames=0 biosdevname=0
 d-i finish-install/reboot_in_progress note
 d-i grub-installer/bootdev string default


### PR DESCRIPTION
Fixes #78.

I've tested that all the boxes I modified build fine (using libvirt) and can be used with vagrant up && vagrant ssh, and that /etc/default/debian contains the expected values.