### PR TITLE
arch: Clean up Hyper-V daemon installation a bit

### DIFF
--- a/http/generic.arch.vagrant.chroot.sh
+++ b/http/generic.arch.vagrant.chroot.sh
@@ -70,7 +70,6 @@ pacman -S --noconfirm git base-devel
 cd /home/vagrant/
 
 KERN=`uname -r | awk -F'-' '{print $1}' | sed -e 's/\.0$//g'`
-MAJOR=`uname -r | awk -F'.' '{print $1}'`
 
 # hypervvssd
 sudo git clone https://aur.archlinux.org/hypervvssd.git hypervvssd && chown -R vagrant:vagrant hypervvssd && cd hypervvssd

--- a/http/generic.arch.vagrant.chroot.sh
+++ b/http/generic.arch.vagrant.chroot.sh
@@ -75,21 +75,18 @@ MAJOR=`uname -r | awk -F'.' '{print $1}'`
 # hypervvssd
 sudo git clone https://aur.archlinux.org/hypervvssd.git hypervvssd && chown -R vagrant:vagrant hypervvssd && cd hypervvssd
 sed --in-place "s/^pkgver=.*/pkgver=$KERN/g" PKGBUILD
-sed --in-place "s/https:\/\/www.kernel.org\/pub\/linux\/kernel\/v[0-9]\.x\/linux-.*.tar.gz/https:\/\/www.kernel.org\/pub\/linux\/kernel\/v$MAJOR.x\/linux-$KERN.tar.gz/g" PKGBUILD
 su --preserve-environment vagrant --command "makepkg --cleanbuild --noconfirm --syncdeps --install"
 cd /home/vagrant/ && rm -rf hypervvssd
 
 # hypervkvpd
 sudo git clone https://aur.archlinux.org/hypervkvpd.git hypervkvpd && chown -R vagrant:vagrant hypervkvpd && cd hypervkvpd
 sed --in-place "s/^pkgver=.*/pkgver=$KERN/g" PKGBUILD
-sed --in-place "s/https:\/\/www.kernel.org\/pub\/linux\/kernel\/v[0-9]\.x\/linux-.*.tar.gz/https:\/\/www.kernel.org\/pub\/linux\/kernel\/v$MAJOR.x\/linux-$KERN.tar.gz/g" PKGBUILD
 su --preserve-environment vagrant --command "makepkg --cleanbuild --noconfirm --syncdeps --install"
 cd /home/vagrant/ && rm -rf hypervkvpd
 
 # hypervfcopyd
 sudo git clone https://aur.archlinux.org/hypervfcopyd.git hypervfcopyd && chown -R vagrant:vagrant hypervfcopyd && cd hypervfcopyd
 sed --in-place "s/^pkgver=.*/pkgver=$KERN/g" PKGBUILD
-sed --in-place "s/https:\/\/www.kernel.org\/pub\/linux\/kernel\/v[0-9]\.x\/linux-.*.tar.gz/https:\/\/www.kernel.org\/pub\/linux\/kernel\/v$MAJOR.x\/linux-$KERN.tar.gz/g" PKGBUILD
 su --preserve-environment vagrant --command "makepkg --cleanbuild --noconfirm --syncdeps --install"
 cd /home/vagrant/ && rm -rf hypervfcopyd
 

--- a/http/generic.arch.vagrant.chroot.sh
+++ b/http/generic.arch.vagrant.chroot.sh
@@ -75,27 +75,21 @@ MAJOR=`uname -r | awk -F'.' '{print $1}'`
 # hypervvssd
 sudo git clone https://aur.archlinux.org/hypervvssd.git hypervvssd && chown -R vagrant:vagrant hypervvssd && cd hypervvssd
 sed --in-place "s/^pkgver=.*/pkgver=$KERN/g" PKGBUILD
-sed --in-place "s/pkgver = .*/pkgver = $KERN/g" .SRCINFO
 sed --in-place "s/https:\/\/www.kernel.org\/pub\/linux\/kernel\/v[0-9]\.x\/linux-.*.tar.gz/https:\/\/www.kernel.org\/pub\/linux\/kernel\/v$MAJOR.x\/linux-$KERN.tar.gz/g" PKGBUILD
-sed --in-place "s/https:\/\/www.kernel.org\/pub\/linux\/kernel\/v[0-9]\.x\/linux-.*.tar.gz/https:\/\/www.kernel.org\/pub\/linux\/kernel\/v$MAJOR.x\/linux-$KERN.tar.gz/g" .SRCINFO
 su --preserve-environment vagrant --command "makepkg --cleanbuild --noconfirm --syncdeps --install"
 cd /home/vagrant/ && rm -rf hypervvssd
 
 # hypervkvpd
 sudo git clone https://aur.archlinux.org/hypervkvpd.git hypervkvpd && chown -R vagrant:vagrant hypervkvpd && cd hypervkvpd
 sed --in-place "s/^pkgver=.*/pkgver=$KERN/g" PKGBUILD
-sed --in-place "s/pkgver = .*/pkgver = $KERN/g" .SRCINFO
 sed --in-place "s/https:\/\/www.kernel.org\/pub\/linux\/kernel\/v[0-9]\.x\/linux-.*.tar.gz/https:\/\/www.kernel.org\/pub\/linux\/kernel\/v$MAJOR.x\/linux-$KERN.tar.gz/g" PKGBUILD
-sed --in-place "s/https:\/\/www.kernel.org\/pub\/linux\/kernel\/v[0-9]\.x\/linux-.*.tar.gz/https:\/\/www.kernel.org\/pub\/linux\/kernel\/v$MAJOR.x\/linux-$KERN.tar.gz/g" .SRCINFO
 su --preserve-environment vagrant --command "makepkg --cleanbuild --noconfirm --syncdeps --install"
 cd /home/vagrant/ && rm -rf hypervkvpd
 
 # hypervfcopyd
 sudo git clone https://aur.archlinux.org/hypervfcopyd.git hypervfcopyd && chown -R vagrant:vagrant hypervfcopyd && cd hypervfcopyd
 sed --in-place "s/^pkgver=.*/pkgver=$KERN/g" PKGBUILD
-sed --in-place "s/pkgver = .*/pkgver = $KERN/g" .SRCINFO
 sed --in-place "s/https:\/\/www.kernel.org\/pub\/linux\/kernel\/v[0-9]\.x\/linux-.*.tar.gz/https:\/\/www.kernel.org\/pub\/linux\/kernel\/v$MAJOR.x\/linux-$KERN.tar.gz/g" PKGBUILD
-sed --in-place "s/https:\/\/www.kernel.org\/pub\/linux\/kernel\/v[0-9]\.x\/linux-.*.tar.gz/https:\/\/www.kernel.org\/pub\/linux\/kernel\/v$MAJOR.x\/linux-$KERN.tar.gz/g" .SRCINFO
 su --preserve-environment vagrant --command "makepkg --cleanbuild --noconfirm --syncdeps --install"
 cd /home/vagrant/ && rm -rf hypervfcopyd
 

--- a/http/magma.arch.vagrant.chroot.sh
+++ b/http/magma.arch.vagrant.chroot.sh
@@ -70,7 +70,6 @@ pacman -S --noconfirm git base-devel
 cd /home/vagrant/
 
 KERN=`uname -r | awk -F'-' '{print $1}' | sed -e 's/\.0$//g'`
-MAJOR=`uname -r | awk -F'.' '{print $1}'`
 
 # hypervvssd
 sudo git clone https://aur.archlinux.org/hypervvssd.git hypervvssd && chown -R vagrant:vagrant hypervvssd && cd hypervvssd

--- a/http/magma.arch.vagrant.chroot.sh
+++ b/http/magma.arch.vagrant.chroot.sh
@@ -75,21 +75,18 @@ MAJOR=`uname -r | awk -F'.' '{print $1}'`
 # hypervvssd
 sudo git clone https://aur.archlinux.org/hypervvssd.git hypervvssd && chown -R vagrant:vagrant hypervvssd && cd hypervvssd
 sed --in-place "s/^pkgver=.*/pkgver=$KERN/g" PKGBUILD
-sed --in-place "s/https:\/\/www.kernel.org\/pub\/linux\/kernel\/v[0-9]\.x\/linux-.*.tar.gz/https:\/\/www.kernel.org\/pub\/linux\/kernel\/v$MAJOR.x\/linux-$KERN.tar.gz/g" PKGBUILD
 su --preserve-environment vagrant --command "makepkg --cleanbuild --noconfirm --syncdeps --install"
 cd /home/vagrant/ && rm -rf hypervvssd
 
 # hypervkvpd
 sudo git clone https://aur.archlinux.org/hypervkvpd.git hypervkvpd && chown -R vagrant:vagrant hypervkvpd && cd hypervkvpd
 sed --in-place "s/^pkgver=.*/pkgver=$KERN/g" PKGBUILD
-sed --in-place "s/https:\/\/www.kernel.org\/pub\/linux\/kernel\/v[0-9]\.x\/linux-.*.tar.gz/https:\/\/www.kernel.org\/pub\/linux\/kernel\/v$MAJOR.x\/linux-$KERN.tar.gz/g" PKGBUILD
 su --preserve-environment vagrant --command "makepkg --cleanbuild --noconfirm --syncdeps --install"
 cd /home/vagrant/ && rm -rf hypervkvpd
 
 # hypervfcopyd
 sudo git clone https://aur.archlinux.org/hypervfcopyd.git hypervfcopyd && chown -R vagrant:vagrant hypervfcopyd && cd hypervfcopyd
 sed --in-place "s/^pkgver=.*/pkgver=$KERN/g" PKGBUILD
-sed --in-place "s/https:\/\/www.kernel.org\/pub\/linux\/kernel\/v[0-9]\.x\/linux-.*.tar.gz/https:\/\/www.kernel.org\/pub\/linux\/kernel\/v$MAJOR.x\/linux-$KERN.tar.gz/g" PKGBUILD
 su --preserve-environment vagrant --command "makepkg --cleanbuild --noconfirm --syncdeps --install"
 cd /home/vagrant/ && rm -rf hypervfcopyd
 

--- a/http/magma.arch.vagrant.chroot.sh
+++ b/http/magma.arch.vagrant.chroot.sh
@@ -75,27 +75,21 @@ MAJOR=`uname -r | awk -F'.' '{print $1}'`
 # hypervvssd
 sudo git clone https://aur.archlinux.org/hypervvssd.git hypervvssd && chown -R vagrant:vagrant hypervvssd && cd hypervvssd
 sed --in-place "s/^pkgver=.*/pkgver=$KERN/g" PKGBUILD
-sed --in-place "s/pkgver = .*/pkgver = $KERN/g" .SRCINFO
 sed --in-place "s/https:\/\/www.kernel.org\/pub\/linux\/kernel\/v[0-9]\.x\/linux-.*.tar.gz/https:\/\/www.kernel.org\/pub\/linux\/kernel\/v$MAJOR.x\/linux-$KERN.tar.gz/g" PKGBUILD
-sed --in-place "s/https:\/\/www.kernel.org\/pub\/linux\/kernel\/v[0-9]\.x\/linux-.*.tar.gz/https:\/\/www.kernel.org\/pub\/linux\/kernel\/v$MAJOR.x\/linux-$KERN.tar.gz/g" .SRCINFO
 su --preserve-environment vagrant --command "makepkg --cleanbuild --noconfirm --syncdeps --install"
 cd /home/vagrant/ && rm -rf hypervvssd
 
 # hypervkvpd
 sudo git clone https://aur.archlinux.org/hypervkvpd.git hypervkvpd && chown -R vagrant:vagrant hypervkvpd && cd hypervkvpd
 sed --in-place "s/^pkgver=.*/pkgver=$KERN/g" PKGBUILD
-sed --in-place "s/pkgver = .*/pkgver = $KERN/g" .SRCINFO
 sed --in-place "s/https:\/\/www.kernel.org\/pub\/linux\/kernel\/v[0-9]\.x\/linux-.*.tar.gz/https:\/\/www.kernel.org\/pub\/linux\/kernel\/v$MAJOR.x\/linux-$KERN.tar.gz/g" PKGBUILD
-sed --in-place "s/https:\/\/www.kernel.org\/pub\/linux\/kernel\/v[0-9]\.x\/linux-.*.tar.gz/https:\/\/www.kernel.org\/pub\/linux\/kernel\/v$MAJOR.x\/linux-$KERN.tar.gz/g" .SRCINFO
 su --preserve-environment vagrant --command "makepkg --cleanbuild --noconfirm --syncdeps --install"
 cd /home/vagrant/ && rm -rf hypervkvpd
 
 # hypervfcopyd
 sudo git clone https://aur.archlinux.org/hypervfcopyd.git hypervfcopyd && chown -R vagrant:vagrant hypervfcopyd && cd hypervfcopyd
 sed --in-place "s/^pkgver=.*/pkgver=$KERN/g" PKGBUILD
-sed --in-place "s/pkgver = .*/pkgver = $KERN/g" .SRCINFO
 sed --in-place "s/https:\/\/www.kernel.org\/pub\/linux\/kernel\/v[0-9]\.x\/linux-.*.tar.gz/https:\/\/www.kernel.org\/pub\/linux\/kernel\/v$MAJOR.x\/linux-$KERN.tar.gz/g" PKGBUILD
-sed --in-place "s/https:\/\/www.kernel.org\/pub\/linux\/kernel\/v[0-9]\.x\/linux-.*.tar.gz/https:\/\/www.kernel.org\/pub\/linux\/kernel\/v$MAJOR.x\/linux-$KERN.tar.gz/g" .SRCINFO
 su --preserve-environment vagrant --command "makepkg --cleanbuild --noconfirm --syncdeps --install"
 cd /home/vagrant/ && rm -rf hypervfcopyd
 


### PR DESCRIPTION
This PR removes the modifications to .SRCINFO (which are unneeded, since it is only used by the AUR, not for building).

Furthermore, the AUR package has been modified to update the `v<major>.x` in the URL automatically whenever the package version (i.e. the current kernel version) is bumped, so the URL modifications can go as well.