### PR TITLE
el8: add python interpreter

### DIFF
--- a/scripts/centos8/dnf.sh
+++ b/scripts/centos8/dnf.sh
@@ -77,7 +77,7 @@ sed --in-place "s/# #/##/g" /etc/yum.repos.d/epel-playground.repo
 retry dnf --assumeyes update
 
 # Install the basic packages we'd expect to find.
-retry dnf --assumeyes install sudo dmidecode dnf-utils bash-completion man man-pages mlocate vim-enhanced bind-utils wget dos2unix unix2dos lsof telnet net-tools coreutils grep gawk sed curl patch sysstat make cmake libarchive autoconf automake libtool gcc-c++ libstdc++-devel gcc cpp ncurses-devel glibc-devel glibc-headers kernel-headers psmisc whois
+retry dnf --assumeyes install sudo dmidecode dnf-utils bash-completion man man-pages mlocate vim-enhanced bind-utils wget dos2unix unix2dos lsof telnet net-tools coreutils grep gawk sed curl patch sysstat make cmake libarchive autoconf automake libtool gcc-c++ libstdc++-devel gcc cpp ncurses-devel glibc-devel glibc-headers kernel-headers psmisc whois python36
 
 if [ -f /etc/yum.repos.d/CentOS-Vault.repo.rpmnew ]; then
   rm --force /etc/yum.repos.d/CentOS-Vault.repo.rpmnew

--- a/scripts/oracle8/dnf.sh
+++ b/scripts/oracle8/dnf.sh
@@ -4,7 +4,7 @@
 dnf --assumeyes update
 
 # The basic utilities we'd expect to find.
-dnf --assumeyes install net-tools dnf-utils bash-completion man-pages vim-enhanced mlocate sysstat bind-utils wget dos2unix unix2dos lsof telnet coreutils grep gawk sed curl psmisc tar
+dnf --assumeyes install net-tools dnf-utils bash-completion man-pages vim-enhanced mlocate sysstat bind-utils wget dos2unix unix2dos lsof telnet coreutils grep gawk sed curl psmisc tar python36
 
 # Schedule a reboot, but give the computer time to cleanly shutdown the
 # network interface first.

--- a/scripts/rhel8/dnf.sh
+++ b/scripts/rhel8/dnf.sh
@@ -437,7 +437,7 @@ sed --in-place "s/^/# /g" /etc/yum.repos.d/epel-playground.repo
 sed --in-place "s/# #/##/g" /etc/yum.repos.d/epel-playground.repo
 
 # Install the basic packages we'd expect to find.
-dnf --assumeyes install sudo dmidecode dnf-utils bash-completion man man-pages vim-enhanced sysstat bind-utils wget dos2unix unix2dos lsof telnet net-tools coreutils grep gawk sed curl patch sysstat make cmake libarchive info autoconf automake libtool gcc-c++ libstdc++-devel gcc cpp ncurses-devel glibc-devel glibc-headers kernel-headers psmisc whois
+dnf --assumeyes install sudo dmidecode dnf-utils bash-completion man man-pages vim-enhanced sysstat bind-utils wget dos2unix unix2dos lsof telnet net-tools coreutils grep gawk sed curl patch sysstat make cmake libarchive info autoconf automake libtool gcc-c++ libstdc++-devel gcc cpp ncurses-devel glibc-devel glibc-headers kernel-headers psmisc whois python36
 
 # For some reason the beta thinks this package is installed, when in fact it's missing.
 dnf --assumeyes reinstall libunistring


### PR DESCRIPTION
Add python interpreter which is missing in the base installation of EL8
and its derivates. Besides other uses, python interpreter is required
for ansible provisioning.