### PR TITLE
Use sata adapter for rhel8

### DIFF
--- a/generic-virtualbox.json
+++ b/generic-virtualbox.json
@@ -2788,6 +2788,8 @@
         ]
       ],
       "guest_os_type": "RedHat_64",
+      "hard_drive_interface": "sata",
+      "sata_port_count": 6,
       "http_directory": "http",
       "headless": true,
       "vrdp_bind_address": "127.0.0.1",
@@ -2796,6 +2798,7 @@
       "iso_url": "https://archive.org/download/rhel-8.0-x86_64-dvd/rhel-8.0-x86_64-dvd.iso",
       "iso_checksum": "005d4f88fff6d63b0fc01a10822380ef52570edd8834321de7be63002cc6cc43",
       "iso_checksum_type": "sha256",
+      "iso_interface": "sata",
       "ssh_username": "root",
       "ssh_password": "vagrant",
       "ssh_port": 22,

--- a/generic-virtualbox.json
+++ b/generic-virtualbox.json
@@ -2785,6 +2785,13 @@
           "{{.Name}}",
           "--vram",
           "64"
+        ],
+        [
+          "storagectl",
+          "{{.Name}}",
+          "--name",
+          "IDE Controller",
+          "--remove"
         ]
       ],
       "guest_os_type": "RedHat_64",

--- a/tpl/generic-rhel8.rb
+++ b/tpl/generic-rhel8.rb
@@ -20,7 +20,7 @@ Vagrant.configure(2) do |config|
   # SHELL
 
   # Adding a second CPU and increasing the RAM to 2048MB will speed
-  # things up considerably should you decide to do anythinc with this box.
+  # things up considerably should you decide to do anything with this box.
   config.vm.provider :hyperv do |v, override|
     v.maxmemory = 2048
     v.memory = 2048
@@ -46,6 +46,8 @@ Vagrant.configure(2) do |config|
     v.customize ["modifyvm", :id, "--memory", 2048]
     v.customize ["modifyvm", :id, "--vram", 256]
     v.customize ["modifyvm", :id, "--cpus", 2]
+    # packer creates an IDE controller which isn't used.
+    v.customize ["storagectl", :id, "--name", "IDE Controller", "--remove"]
     v.gui = false
   end
 

--- a/tpl/generic-rhel8.rb
+++ b/tpl/generic-rhel8.rb
@@ -20,7 +20,7 @@ Vagrant.configure(2) do |config|
   # SHELL
 
   # Adding a second CPU and increasing the RAM to 2048MB will speed
-  # things up considerably should you decide to do anything with this box.
+  # things up considerably should you decide to do anythinc with this box.
   config.vm.provider :hyperv do |v, override|
     v.maxmemory = 2048
     v.memory = 2048
@@ -46,8 +46,6 @@ Vagrant.configure(2) do |config|
     v.customize ["modifyvm", :id, "--memory", 2048]
     v.customize ["modifyvm", :id, "--vram", 256]
     v.customize ["modifyvm", :id, "--cpus", 2]
-    # packer creates an IDE controller which isn't used.
-    v.customize ["storagectl", :id, "--name", "IDE Controller", "--remove"]
     v.gui = false
   end
 


### PR DESCRIPTION
Changes the RHEL8 box to use a SATA Controller instead of IDE, making it easier to add drives later as well as potentially offering performance benefits. The IDE Controller is removed by packer. 