### PR TITLE
fedora31: Update `disk_bus` as `virtio`

### DIFF
--- a/tpl/generic-fedora31.rb
+++ b/tpl/generic-fedora31.rb
@@ -28,7 +28,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provider :libvirt do |v, override|
-    v.disk_bus = "scsi"
+    v.disk_bus = "virtio"
     v.driver = "kvm"
     v.video_vram = 256
     v.memory = 2048

--- a/tpl/roboxes-fedora31.rb
+++ b/tpl/roboxes-fedora31.rb
@@ -28,7 +28,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provider :libvirt do |v, override|
-    v.disk_bus = "scsi"
+    v.disk_bus = "virtio"
     v.driver = "kvm"
     v.video_vram = 256
     v.memory = 2048


### PR DESCRIPTION
Update Fedora 31 default `disk_bus` as `virtio`.

Clone changes from https://github.com/lavabit/robox/commit/69c958a87b507723b8e53f48880670cc4410d719

Fix #96