### PR TITLE
centos7: Update `disk_bus` as `virtio`

### DIFF
--- a/tpl/generic-centos7.rb
+++ b/tpl/generic-centos7.rb
@@ -28,7 +28,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provider :libvirt do |v, override|
-    v.disk_bus = "scsi"
+    v.disk_bus = "virtio"
     v.driver = "kvm"
     v.video_vram = 256
     v.memory = 2048
@@ -51,6 +51,7 @@ Vagrant.configure(2) do |config|
 
   ["vmware_fusion", "vmware_workstation", "vmware_desktop"].each do |provider|
     config.vm.provider provider do |v, override|
+      v.ssh_info_public = true
       v.whitelist_verified = true
       v.gui = false
       v.vmx["cpuid.coresPerSocket"] = "1"

--- a/tpl/roboxes-centos7.rb
+++ b/tpl/roboxes-centos7.rb
@@ -28,7 +28,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provider :libvirt do |v, override|
-    v.disk_bus = "scsi"
+    v.disk_bus = "virtio"
     v.driver = "kvm"
     v.video_vram = 256
     v.memory = 2048
@@ -51,6 +51,7 @@ Vagrant.configure(2) do |config|
 
   ["vmware_fusion", "vmware_workstation", "vmware_desktop"].each do |provider|
     config.vm.provider provider do |v, override|
+      v.ssh_info_public = true
       v.whitelist_verified = true
       v.gui = false
       v.vmx["cpuid.coresPerSocket"] = "1"


### PR DESCRIPTION
Update CentOS 7 default `disk_bus` as `virtio`.

Clone changes from https://github.com/lavabit/robox/commit/69c958a87b507723b8e53f48880670cc4410d719

Fix #96