### PR TITLE
Fix hostnames being set to "bazinga".

### DIFF
--- a/generic-hyperv.json
+++ b/generic-hyperv.json
@@ -63,7 +63,7 @@
         "scripts/alpine35/network.sh",
         "scripts/alpine35/apk.sh"
       ],
-      "execute_command": "/bin/sh '{{.Path}}'",
+      "execute_command": "{{.Vars}} /bin/sh '{{.Path}}'",
       "start_retry_timeout": "45m",
       "expect_disconnect": "true",
       "only": [
@@ -98,7 +98,7 @@
         "scripts/alpine36/network.sh",
         "scripts/alpine36/apk.sh"
       ],
-      "execute_command": "/bin/sh '{{.Path}}'",
+      "execute_command": "{{.Vars}} /bin/sh '{{.Path}}'",
       "start_retry_timeout": "45m",
       "expect_disconnect": "true",
       "only": [
@@ -133,7 +133,7 @@
         "scripts/alpine37/network.sh",
         "scripts/alpine37/apk.sh"
       ],
-      "execute_command": "/bin/sh '{{.Path}}'",
+      "execute_command": "{{.Vars}} /bin/sh '{{.Path}}'",
       "start_retry_timeout": "45m",
       "expect_disconnect": "true",
       "only": [
@@ -168,7 +168,7 @@
         "scripts/alpine38/network.sh",
         "scripts/alpine38/apk.sh"
       ],
-      "execute_command": "/bin/sh '{{.Path}}'",
+      "execute_command": "{{.Vars}} /bin/sh '{{.Path}}'",
       "start_retry_timeout": "45m",
       "expect_disconnect": "true",
       "only": [
@@ -666,7 +666,7 @@
       ],
       "start_retry_timeout": "45m",
       "expect_disconnect": "true",
-      "execute_command": "/usr/local/bin/bash {{ .Path }}",
+      "execute_command": "{{.Vars}} /usr/local/bin/bash {{ .Path }}",
       "only": [
         "generic-freebsd11-hyperv"
       ]
@@ -678,7 +678,7 @@
       ],
       "start_retry_timeout": "45m",
       "expect_disconnect": "true",
-      "execute_command": "/bin/sh {{ .Path }}",
+      "execute_command": "{{.Vars}} /bin/sh {{ .Path }}",
       "only": [
         "generic-openbsd6-hyperv"
       ]
@@ -698,7 +698,7 @@
       "pause_before": "120s",
       "start_retry_timeout": "45m",
       "expect_disconnect": "true",
-      "execute_command": "/usr/local/bin/bash {{ .Path }}",
+      "execute_command": "{{.Vars}} /usr/local/bin/bash {{ .Path }}",
       "only": [
         "generic-openbsd6-hyperv"
       ]
@@ -912,7 +912,7 @@
       ],
       "start_retry_timeout": "45m",
       "expect_disconnect": "true",
-      "execute_command": "/usr/local/bin/bash {{ .Path }}",
+      "execute_command": "{{.Vars}} /usr/local/bin/bash {{ .Path }}",
       "only": [
         "generic-freebsd12-hyperv"
       ]
@@ -1014,7 +1014,7 @@
       ],
       "start_retry_timeout": "45m",
       "expect_disconnect": "true",
-      "execute_command": "/usr/local/bin/bash {{ .Path }}",
+      "execute_command": "{{.Vars}} /usr/local/bin/bash {{ .Path }}",
       "only": [
         "generic-hardenedbsd11-hyperv"
       ]
@@ -1036,7 +1036,7 @@
       ],
       "start_retry_timeout": "45m",
       "expect_disconnect": "true",
-      "execute_command": "/usr/local/bin/bash {{ .Path }}",
+      "execute_command": "{{.Vars}} /usr/local/bin/bash {{ .Path }}",
       "only": [
         "generic-dragonflybsd5-hyperv"
       ]
@@ -1048,7 +1048,7 @@
       ],
       "start_retry_timeout": "45m",
       "expect_disconnect": "true",
-      "execute_command": "/bin/sh {{ .Path }}",
+      "execute_command": "{{.Vars}} /bin/sh {{ .Path }}",
       "only": [
         "generic-netbsd8-hyperv"
       ]
@@ -1090,7 +1090,7 @@
       ],
       "start_retry_timeout": "45m",
       "expect_disconnect": "true",
-      "execute_command": "/usr/local/bin/bash {{ .Path }}",
+      "execute_command": "{{.Vars}} /usr/local/bin/bash {{ .Path }}",
       "only": [
         "generic-hardenedbsd12-hyperv"
       ]
@@ -1101,7 +1101,7 @@
         "scripts/alpine39/network.sh",
         "scripts/alpine39/apk.sh"
       ],
-      "execute_command": "/bin/sh '{{.Path}}'",
+      "execute_command": "{{.Vars}} /bin/sh '{{.Path}}'",
       "start_retry_timeout": "45m",
       "expect_disconnect": "true",
       "only": [
@@ -1277,7 +1277,7 @@
         "scripts/alpine310/network.sh",
         "scripts/alpine310/apk.sh"
       ],
-      "execute_command": "/bin/sh '{{.Path}}'",
+      "execute_command": "{{.Vars}} /bin/sh '{{.Path}}'",
       "start_retry_timeout": "45m",
       "expect_disconnect": "true",
       "only": [

--- a/generic-libvirt.json
+++ b/generic-libvirt.json
@@ -63,7 +63,7 @@
         "scripts/alpine35/network.sh",
         "scripts/alpine35/apk.sh"
       ],
-      "execute_command": "/bin/sh '{{.Path}}'",
+      "execute_command": "{{.Vars}} /bin/sh '{{.Path}}'",
       "start_retry_timeout": "15m",
       "expect_disconnect": "true",
       "only": [
@@ -98,7 +98,7 @@
         "scripts/alpine36/network.sh",
         "scripts/alpine36/apk.sh"
       ],
-      "execute_command": "/bin/sh '{{.Path}}'",
+      "execute_command": "{{.Vars}} /bin/sh '{{.Path}}'",
       "start_retry_timeout": "15m",
       "expect_disconnect": "true",
       "only": [
@@ -133,7 +133,7 @@
         "scripts/alpine37/network.sh",
         "scripts/alpine37/apk.sh"
       ],
-      "execute_command": "/bin/sh '{{.Path}}'",
+      "execute_command": "{{.Vars}} /bin/sh '{{.Path}}'",
       "start_retry_timeout": "15m",
       "expect_disconnect": "true",
       "only": [
@@ -168,7 +168,7 @@
         "scripts/alpine38/network.sh",
         "scripts/alpine38/apk.sh"
       ],
-      "execute_command": "/bin/sh '{{.Path}}'",
+      "execute_command": "{{.Vars}} /bin/sh '{{.Path}}'",
       "start_retry_timeout": "15m",
       "expect_disconnect": "true",
       "only": [
@@ -666,7 +666,7 @@
       "type": "shell",
       "start_retry_timeout": "15m",
       "expect_disconnect": "true",
-      "execute_command": "/usr/local/bin/bash {{ .Path }}",
+      "execute_command": "{{.Vars}} /usr/local/bin/bash {{ .Path }}",
       "only": [
         "generic-freebsd11-libvirt"
       ]
@@ -678,7 +678,7 @@
       "type": "shell",
       "start_retry_timeout": "15m",
       "expect_disconnect": "true",
-      "execute_command": "/bin/sh {{ .Path }}",
+      "execute_command": "{{.Vars}} /bin/sh {{ .Path }}",
       "only": [
         "generic-openbsd6-libvirt"
       ]
@@ -698,7 +698,7 @@
       "pause_before": "120s",
       "start_retry_timeout": "15m",
       "expect_disconnect": "true",
-      "execute_command": "/usr/local/bin/bash {{ .Path }}",
+      "execute_command": "{{.Vars}} /usr/local/bin/bash {{ .Path }}",
       "only": [
         "generic-openbsd6-libvirt"
       ]
@@ -912,7 +912,7 @@
       "type": "shell",
       "start_retry_timeout": "15m",
       "expect_disconnect": "true",
-      "execute_command": "/usr/local/bin/bash {{ .Path }}",
+      "execute_command": "{{.Vars}} /usr/local/bin/bash {{ .Path }}",
       "only": [
         "generic-freebsd12-libvirt"
       ]
@@ -1014,7 +1014,7 @@
       "type": "shell",
       "start_retry_timeout": "15m",
       "expect_disconnect": "true",
-      "execute_command": "/usr/local/bin/bash {{ .Path }}",
+      "execute_command": "{{.Vars}} /usr/local/bin/bash {{ .Path }}",
       "only": [
         "generic-hardenedbsd11-libvirt"
       ]
@@ -1036,7 +1036,7 @@
       "type": "shell",
       "start_retry_timeout": "15m",
       "expect_disconnect": "true",
-      "execute_command": "/usr/local/bin/bash {{ .Path }}",
+      "execute_command": "{{.Vars}} /usr/local/bin/bash {{ .Path }}",
       "only": [
         "generic-dragonflybsd5-libvirt"
       ]
@@ -1048,7 +1048,7 @@
       "type": "shell",
       "start_retry_timeout": "15m",
       "expect_disconnect": "true",
-      "execute_command": "/bin/sh {{ .Path }}",
+      "execute_command": "{{.Vars}} /bin/sh {{ .Path }}",
       "only": [
         "generic-netbsd8-libvirt"
       ]
@@ -1090,7 +1090,7 @@
       "type": "shell",
       "start_retry_timeout": "15m",
       "expect_disconnect": "true",
-      "execute_command": "/usr/local/bin/bash {{ .Path }}",
+      "execute_command": "{{.Vars}} /usr/local/bin/bash {{ .Path }}",
       "only": [
         "generic-hardenedbsd12-libvirt"
       ]
@@ -1101,7 +1101,7 @@
         "scripts/alpine39/network.sh",
         "scripts/alpine39/apk.sh"
       ],
-      "execute_command": "/bin/sh '{{.Path}}'",
+      "execute_command": "{{.Vars}} /bin/sh '{{.Path}}'",
       "start_retry_timeout": "15m",
       "expect_disconnect": "true",
       "only": [
@@ -1277,7 +1277,7 @@
         "scripts/alpine310/network.sh",
         "scripts/alpine310/apk.sh"
       ],
-      "execute_command": "/bin/sh '{{.Path}}'",
+      "execute_command": "{{.Vars}} /bin/sh '{{.Path}}'",
       "start_retry_timeout": "15m",
       "expect_disconnect": "true",
       "only": [

--- a/generic-parallels.json
+++ b/generic-parallels.json
@@ -63,7 +63,7 @@
         "scripts/alpine35/network.sh",
         "scripts/alpine35/apk.sh"
       ],
-      "execute_command": "/bin/sh '{{.Path}}'",
+      "execute_command": "{{.Vars}} /bin/sh '{{.Path}}'",
       "start_retry_timeout": "45m",
       "expect_disconnect": "true",
       "only": [
@@ -98,7 +98,7 @@
         "scripts/alpine36/network.sh",
         "scripts/alpine36/apk.sh"
       ],
-      "execute_command": "/bin/sh '{{.Path}}'",
+      "execute_command": "{{.Vars}} /bin/sh '{{.Path}}'",
       "start_retry_timeout": "45m",
       "expect_disconnect": "true",
       "only": [
@@ -133,7 +133,7 @@
         "scripts/alpine37/network.sh",
         "scripts/alpine37/apk.sh"
       ],
-      "execute_command": "/bin/sh '{{.Path}}'",
+      "execute_command": "{{.Vars}} /bin/sh '{{.Path}}'",
       "start_retry_timeout": "45m",
       "expect_disconnect": "true",
       "only": [
@@ -168,7 +168,7 @@
         "scripts/alpine38/network.sh",
         "scripts/alpine38/apk.sh"
       ],
-      "execute_command": "/bin/sh '{{.Path}}'",
+      "execute_command": "{{.Vars}} /bin/sh '{{.Path}}'",
       "start_retry_timeout": "45m",
       "expect_disconnect": "true",
       "only": [
@@ -666,7 +666,7 @@
       "type": "shell",
       "start_retry_timeout": "45m",
       "expect_disconnect": "true",
-      "execute_command": "/usr/local/bin/bash {{ .Path }}",
+      "execute_command": "{{.Vars}} /usr/local/bin/bash {{ .Path }}",
       "only": [
         "generic-freebsd11-parallels"
       ]
@@ -678,7 +678,7 @@
       "type": "shell",
       "start_retry_timeout": "45m",
       "expect_disconnect": "true",
-      "execute_command": "/bin/sh {{ .Path }}",
+      "execute_command": "{{.Vars}} /bin/sh {{ .Path }}",
       "only": [
         "generic-openbsd6-parallels"
       ]
@@ -698,7 +698,7 @@
       "pause_before": "120s",
       "start_retry_timeout": "45m",
       "expect_disconnect": "true",
-      "execute_command": "/usr/local/bin/bash {{ .Path }}",
+      "execute_command": "{{.Vars}} /usr/local/bin/bash {{ .Path }}",
       "only": [
         "generic-openbsd6-parallels"
       ]
@@ -912,7 +912,7 @@
       "type": "shell",
       "start_retry_timeout": "45m",
       "expect_disconnect": "true",
-      "execute_command": "/usr/local/bin/bash {{ .Path }}",
+      "execute_command": "{{.Vars}} /usr/local/bin/bash {{ .Path }}",
       "only": [
         "generic-freebsd12-parallels"
       ]
@@ -1014,7 +1014,7 @@
       "type": "shell",
       "start_retry_timeout": "45m",
       "expect_disconnect": "true",
-      "execute_command": "/usr/local/bin/bash {{ .Path }}",
+      "execute_command": "{{.Vars}} /usr/local/bin/bash {{ .Path }}",
       "only": [
         "generic-hardenedbsd11-parallels"
       ]
@@ -1036,7 +1036,7 @@
       "type": "shell",
       "start_retry_timeout": "45m",
       "expect_disconnect": "true",
-      "execute_command": "/usr/local/bin/bash {{ .Path }}",
+      "execute_command": "{{.Vars}} /usr/local/bin/bash {{ .Path }}",
       "only": [
         "generic-dragonflybsd5-parallels"
       ]
@@ -1048,7 +1048,7 @@
       "type": "shell",
       "start_retry_timeout": "45m",
       "expect_disconnect": "true",
-      "execute_command": "/bin/sh {{ .Path }}",
+      "execute_command": "{{.Vars}} /bin/sh {{ .Path }}",
       "only": [
         "generic-netbsd8-parallels"
       ]
@@ -1090,7 +1090,7 @@
       "type": "shell",
       "start_retry_timeout": "45m",
       "expect_disconnect": "true",
-      "execute_command": "/usr/local/bin/bash {{ .Path }}",
+      "execute_command": "{{.Vars}} /usr/local/bin/bash {{ .Path }}",
       "only": [
         "generic-hardenedbsd12-parallels"
       ]
@@ -1101,7 +1101,7 @@
         "scripts/alpine39/network.sh",
         "scripts/alpine39/apk.sh"
       ],
-      "execute_command": "/bin/sh '{{.Path}}'",
+      "execute_command": "{{.Vars}} /bin/sh '{{.Path}}'",
       "start_retry_timeout": "45m",
       "expect_disconnect": "true",
       "only": [
@@ -1277,7 +1277,7 @@
         "scripts/alpine310/network.sh",
         "scripts/alpine310/apk.sh"
       ],
-      "execute_command": "/bin/sh '{{.Path}}'",
+      "execute_command": "{{.Vars}} /bin/sh '{{.Path}}'",
       "start_retry_timeout": "45m",
       "expect_disconnect": "true",
       "only": [

--- a/generic-virtualbox.json
+++ b/generic-virtualbox.json
@@ -63,7 +63,7 @@
         "scripts/alpine35/network.sh",
         "scripts/alpine35/apk.sh"
       ],
-      "execute_command": "/bin/sh '{{.Path}}'",
+      "execute_command": "{{.Vars}} /bin/sh '{{.Path}}'",
       "start_retry_timeout": "15m",
       "expect_disconnect": "true",
       "only": [
@@ -98,7 +98,7 @@
         "scripts/alpine36/network.sh",
         "scripts/alpine36/apk.sh"
       ],
-      "execute_command": "/bin/sh '{{.Path}}'",
+      "execute_command": "{{.Vars}} /bin/sh '{{.Path}}'",
       "start_retry_timeout": "15m",
       "expect_disconnect": "true",
       "only": [
@@ -133,7 +133,7 @@
         "scripts/alpine37/network.sh",
         "scripts/alpine37/apk.sh"
       ],
-      "execute_command": "/bin/sh '{{.Path}}'",
+      "execute_command": "{{.Vars}} /bin/sh '{{.Path}}'",
       "start_retry_timeout": "15m",
       "expect_disconnect": "true",
       "only": [
@@ -168,7 +168,7 @@
         "scripts/alpine38/network.sh",
         "scripts/alpine38/apk.sh"
       ],
-      "execute_command": "/bin/sh '{{.Path}}'",
+      "execute_command": "{{.Vars}} /bin/sh '{{.Path}}'",
       "start_retry_timeout": "15m",
       "expect_disconnect": "true",
       "only": [
@@ -666,7 +666,7 @@
       "type": "shell",
       "start_retry_timeout": "15m",
       "expect_disconnect": "true",
-      "execute_command": "/usr/local/bin/bash {{ .Path }}",
+      "execute_command": "{{.Vars}} /usr/local/bin/bash {{ .Path }}",
       "only": [
         "generic-freebsd11-virtualbox"
       ]
@@ -678,7 +678,7 @@
       "type": "shell",
       "start_retry_timeout": "15m",
       "expect_disconnect": "true",
-      "execute_command": "/bin/sh {{ .Path }}",
+      "execute_command": "{{.Vars}} /bin/sh {{ .Path }}",
       "only": [
         "generic-openbsd6-virtualbox"
       ]
@@ -698,7 +698,7 @@
       "pause_before": "120s",
       "start_retry_timeout": "15m",
       "expect_disconnect": "true",
-      "execute_command": "/usr/local/bin/bash {{ .Path }}",
+      "execute_command": "{{.Vars}} /usr/local/bin/bash {{ .Path }}",
       "only": [
         "generic-openbsd6-virtualbox"
       ]
@@ -912,7 +912,7 @@
       "type": "shell",
       "start_retry_timeout": "15m",
       "expect_disconnect": "true",
-      "execute_command": "/usr/local/bin/bash {{ .Path }}",
+      "execute_command": "{{.Vars}} /usr/local/bin/bash {{ .Path }}",
       "only": [
         "generic-freebsd12-virtualbox"
       ]
@@ -1014,7 +1014,7 @@
       "type": "shell",
       "start_retry_timeout": "15m",
       "expect_disconnect": "true",
-      "execute_command": "/usr/local/bin/bash {{ .Path }}",
+      "execute_command": "{{.Vars}} /usr/local/bin/bash {{ .Path }}",
       "only": [
         "generic-hardenedbsd11-virtualbox"
       ]
@@ -1036,7 +1036,7 @@
       "type": "shell",
       "start_retry_timeout": "15m",
       "expect_disconnect": "true",
-      "execute_command": "/usr/local/bin/bash {{ .Path }}",
+      "execute_command": "{{.Vars}} /usr/local/bin/bash {{ .Path }}",
       "only": [
         "generic-dragonflybsd5-virtualbox"
       ]
@@ -1048,7 +1048,7 @@
       "type": "shell",
       "start_retry_timeout": "15m",
       "expect_disconnect": "true",
-      "execute_command": "/bin/sh {{ .Path }}",
+      "execute_command": "{{.Vars}} /bin/sh {{ .Path }}",
       "only": [
         "generic-netbsd8-virtualbox"
       ]
@@ -1090,7 +1090,7 @@
       "type": "shell",
       "start_retry_timeout": "15m",
       "expect_disconnect": "true",
-      "execute_command": "/usr/local/bin/bash {{ .Path }}",
+      "execute_command": "{{.Vars}} /usr/local/bin/bash {{ .Path }}",
       "only": [
         "generic-hardenedbsd12-virtualbox"
       ]
@@ -1101,7 +1101,7 @@
         "scripts/alpine39/network.sh",
         "scripts/alpine39/apk.sh"
       ],
-      "execute_command": "/bin/sh '{{.Path}}'",
+      "execute_command": "{{.Vars}} /bin/sh '{{.Path}}'",
       "start_retry_timeout": "15m",
       "expect_disconnect": "true",
       "only": [
@@ -1277,7 +1277,7 @@
         "scripts/alpine310/network.sh",
         "scripts/alpine310/apk.sh"
       ],
-      "execute_command": "/bin/sh '{{.Path}}'",
+      "execute_command": "{{.Vars}} /bin/sh '{{.Path}}'",
       "start_retry_timeout": "15m",
       "expect_disconnect": "true",
       "only": [

--- a/generic-vmware.json
+++ b/generic-vmware.json
@@ -63,7 +63,7 @@
         "scripts/alpine35/network.sh",
         "scripts/alpine35/apk.sh"
       ],
-      "execute_command": "/bin/sh '{{.Path}}'",
+      "execute_command": "{{.Vars}} /bin/sh '{{.Path}}'",
       "start_retry_timeout": "15m",
       "expect_disconnect": "true",
       "only": [
@@ -98,7 +98,7 @@
         "scripts/alpine36/network.sh",
         "scripts/alpine36/apk.sh"
       ],
-      "execute_command": "/bin/sh '{{.Path}}'",
+      "execute_command": "{{.Vars}} /bin/sh '{{.Path}}'",
       "start_retry_timeout": "15m",
       "expect_disconnect": "true",
       "only": [
@@ -133,7 +133,7 @@
         "scripts/alpine37/network.sh",
         "scripts/alpine37/apk.sh"
       ],
-      "execute_command": "/bin/sh '{{.Path}}'",
+      "execute_command": "{{.Vars}} /bin/sh '{{.Path}}'",
       "start_retry_timeout": "15m",
       "expect_disconnect": "true",
       "only": [
@@ -168,7 +168,7 @@
         "scripts/alpine38/network.sh",
         "scripts/alpine38/apk.sh"
       ],
-      "execute_command": "/bin/sh '{{.Path}}'",
+      "execute_command": "{{.Vars}} /bin/sh '{{.Path}}'",
       "start_retry_timeout": "15m",
       "expect_disconnect": "true",
       "only": [
@@ -666,7 +666,7 @@
       "type": "shell",
       "start_retry_timeout": "15m",
       "expect_disconnect": "true",
-      "execute_command": "/usr/local/bin/bash {{ .Path }}",
+      "execute_command": "{{.Vars}} /usr/local/bin/bash {{ .Path }}",
       "only": [
         "generic-freebsd11-vmware"
       ]
@@ -678,7 +678,7 @@
       "type": "shell",
       "start_retry_timeout": "15m",
       "expect_disconnect": "true",
-      "execute_command": "/bin/sh {{ .Path }}",
+      "execute_command": "{{.Vars}} /bin/sh {{ .Path }}",
       "only": [
         "generic-openbsd6-vmware"
       ]
@@ -698,7 +698,7 @@
       "pause_before": "120s",
       "start_retry_timeout": "15m",
       "expect_disconnect": "true",
-      "execute_command": "/usr/local/bin/bash {{ .Path }}",
+      "execute_command": "{{.Vars}} /usr/local/bin/bash {{ .Path }}",
       "only": [
         "generic-openbsd6-vmware"
       ]
@@ -912,7 +912,7 @@
       "type": "shell",
       "start_retry_timeout": "15m",
       "expect_disconnect": "true",
-      "execute_command": "/usr/local/bin/bash {{ .Path }}",
+      "execute_command": "{{.Vars}} /usr/local/bin/bash {{ .Path }}",
       "only": [
         "generic-freebsd12-vmware"
       ]
@@ -1014,7 +1014,7 @@
       "type": "shell",
       "start_retry_timeout": "15m",
       "expect_disconnect": "true",
-      "execute_command": "/usr/local/bin/bash {{ .Path }}",
+      "execute_command": "{{.Vars}} /usr/local/bin/bash {{ .Path }}",
       "only": [
         "generic-hardenedbsd11-vmware"
       ]
@@ -1036,7 +1036,7 @@
       "type": "shell",
       "start_retry_timeout": "15m",
       "expect_disconnect": "true",
-      "execute_command": "/usr/local/bin/bash {{ .Path }}",
+      "execute_command": "{{.Vars}} /usr/local/bin/bash {{ .Path }}",
       "only": [
         "generic-dragonflybsd5-vmware"
       ]
@@ -1048,7 +1048,7 @@
       "type": "shell",
       "start_retry_timeout": "15m",
       "expect_disconnect": "true",
-      "execute_command": "/bin/sh {{ .Path }}",
+      "execute_command": "{{.Vars}} /bin/sh {{ .Path }}",
       "only": [
         "generic-netbsd8-vmware"
       ]
@@ -1090,7 +1090,7 @@
       "type": "shell",
       "start_retry_timeout": "15m",
       "expect_disconnect": "true",
-      "execute_command": "/usr/local/bin/bash {{ .Path }}",
+      "execute_command": "{{.Vars}} /usr/local/bin/bash {{ .Path }}",
       "only": [
         "generic-hardenedbsd12-vmware"
       ]
@@ -1101,7 +1101,7 @@
         "scripts/alpine39/network.sh",
         "scripts/alpine39/apk.sh"
       ],
-      "execute_command": "/bin/sh '{{.Path}}'",
+      "execute_command": "{{.Vars}} /bin/sh '{{.Path}}'",
       "start_retry_timeout": "15m",
       "expect_disconnect": "true",
       "only": [
@@ -1277,7 +1277,7 @@
         "scripts/alpine310/network.sh",
         "scripts/alpine310/apk.sh"
       ],
-      "execute_command": "/bin/sh '{{.Path}}'",
+      "execute_command": "{{.Vars}} /bin/sh '{{.Path}}'",
       "start_retry_timeout": "15m",
       "expect_disconnect": "true",
       "only": [

--- a/magma-hyperv.json
+++ b/magma-hyperv.json
@@ -9,7 +9,7 @@
                 "scripts/alpine36/network.sh",
                 "scripts/alpine36/apk.sh"
             ],
-            "execute_command": "/bin/sh '{{.Path}}'",
+            "execute_command": "{{.Vars}} /bin/sh '{{.Path}}'",
             "start_retry_timeout": "45m",
             "expect_disconnect": "true",
             "only": [
@@ -292,7 +292,7 @@
             "type": "shell",
             "start_retry_timeout": "45m",
             "expect_disconnect": "true",
-            "execute_command": "/usr/local/bin/bash {{ .Path }}",
+            "execute_command": "{{.Vars}} /usr/local/bin/bash {{ .Path }}",
             "only": [
                 "magma-freebsd11-hyperv"
             ]
@@ -304,7 +304,7 @@
             "type": "shell",
             "start_retry_timeout": "45m",
             "expect_disconnect": "true",
-            "execute_command": "/bin/sh {{ .Path }}",
+            "execute_command": "{{.Vars}} /bin/sh {{ .Path }}",
             "only": [
                 "magma-openbsd6-hyperv"
             ]
@@ -325,7 +325,7 @@
             "pause_before": "120s",
             "start_retry_timeout": "45m",
             "expect_disconnect": "true",
-            "execute_command": "/usr/local/bin/bash {{ .Path }}",
+            "execute_command": "{{.Vars}} /usr/local/bin/bash {{ .Path }}",
             "only": [
                 "magma-openbsd6-hyperv"
             ]

--- a/magma-libvirt.json
+++ b/magma-libvirt.json
@@ -9,7 +9,7 @@
                 "scripts/alpine36/network.sh",
                 "scripts/alpine36/apk.sh"
             ],
-            "execute_command": "/bin/sh '{{.Path}}'",
+            "execute_command": "{{.Vars}} /bin/sh '{{.Path}}'",
             "start_retry_timeout": "15m",
             "expect_disconnect": "true",
             "only": [
@@ -291,7 +291,7 @@
             "type": "shell",
             "start_retry_timeout": "15m",
             "expect_disconnect": "true",
-            "execute_command": "/usr/local/bin/bash {{ .Path }}",
+            "execute_command": "{{.Vars}} /usr/local/bin/bash {{ .Path }}",
             "only": [
                 "magma-freebsd11-libvirt"
             ]
@@ -303,7 +303,7 @@
             "type": "shell",
             "start_retry_timeout": "15m",
             "expect_disconnect": "true",
-            "execute_command": "/bin/sh {{ .Path }}",
+            "execute_command": "{{.Vars}} /bin/sh {{ .Path }}",
             "only": [
                 "magma-openbsd6-libvirt"
             ]
@@ -324,7 +324,7 @@
             "pause_before": "120s",
             "start_retry_timeout": "15m",
             "expect_disconnect": "true",
-            "execute_command": "/usr/local/bin/bash {{ .Path }}",
+            "execute_command": "{{.Vars}} /usr/local/bin/bash {{ .Path }}",
             "only": [
                 "magma-openbsd6-libvirt"
             ]

--- a/magma-virtualbox.json
+++ b/magma-virtualbox.json
@@ -9,7 +9,7 @@
                 "scripts/alpine36/network.sh",
                 "scripts/alpine36/apk.sh"
             ],
-            "execute_command": "/bin/sh '{{.Path}}'",
+            "execute_command": "{{.Vars}} /bin/sh '{{.Path}}'",
             "start_retry_timeout": "15m",
             "expect_disconnect": "true",
             "only": [
@@ -291,7 +291,7 @@
             "type": "shell",
             "start_retry_timeout": "15m",
             "expect_disconnect": "true",
-            "execute_command": "/usr/local/bin/bash {{ .Path }}",
+            "execute_command": "{{.Vars}} /usr/local/bin/bash {{ .Path }}",
             "only": [
                 "magma-freebsd11-virtualbox"
             ]
@@ -303,7 +303,7 @@
             "type": "shell",
             "start_retry_timeout": "15m",
             "expect_disconnect": "true",
-            "execute_command": "/bin/sh {{ .Path }}",
+            "execute_command": "{{.Vars}} /bin/sh {{ .Path }}",
             "only": [
                 "magma-openbsd6-virtualbox"
             ]
@@ -324,7 +324,7 @@
             "pause_before": "120s",
             "start_retry_timeout": "15m",
             "expect_disconnect": "true",
-            "execute_command": "/usr/local/bin/bash {{ .Path }}",
+            "execute_command": "{{.Vars}} /usr/local/bin/bash {{ .Path }}",
             "only": [
                 "magma-openbsd6-virtualbox"
             ]

--- a/magma-vmware.json
+++ b/magma-vmware.json
@@ -9,7 +9,7 @@
                 "scripts/alpine36/network.sh",
                 "scripts/alpine36/apk.sh"
             ],
-            "execute_command": "/bin/sh '{{.Path}}'",
+            "execute_command": "{{.Vars}} /bin/sh '{{.Path}}'",
             "start_retry_timeout": "15m",
             "expect_disconnect": "true",
             "only": [
@@ -291,7 +291,7 @@
             "type": "shell",
             "start_retry_timeout": "15m",
             "expect_disconnect": "true",
-            "execute_command": "/usr/local/bin/bash {{ .Path }}",
+            "execute_command": "{{.Vars}} /usr/local/bin/bash {{ .Path }}",
             "only": [
                 "magma-freebsd11-vmware"
             ]
@@ -303,7 +303,7 @@
             "type": "shell",
             "start_retry_timeout": "15m",
             "expect_disconnect": "true",
-            "execute_command": "/bin/sh {{ .Path }}",
+            "execute_command": "{{.Vars}} /bin/sh {{ .Path }}",
             "only": [
                 "magma-openbsd6-vmware"
             ]
@@ -324,7 +324,7 @@
             "pause_before": "120s",
             "start_retry_timeout": "15m",
             "expect_disconnect": "true",
-            "execute_command": "/usr/local/bin/bash {{ .Path }}",
+            "execute_command": "{{.Vars}} /usr/local/bin/bash {{ .Path }}",
             "only": [
                 "magma-openbsd6-vmware"
             ]

--- a/tpl/generic-alpine310.rb
+++ b/tpl/generic-alpine310.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "generic/bazinga"
-  # config.vm.hostname = "bazinga.box"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/generic-alpine35.rb
+++ b/tpl/generic-alpine35.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "generic/bazinga"
-  # config.vm.hostname = "bazinga.box"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/generic-alpine36.rb
+++ b/tpl/generic-alpine36.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "generic/bazinga"
-  # config.vm.hostname = "bazinga.box"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/generic-alpine37.rb
+++ b/tpl/generic-alpine37.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "generic/bazinga"
-  # config.vm.hostname = "bazinga.box"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/generic-alpine38.rb
+++ b/tpl/generic-alpine38.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "generic/bazinga"
-  # config.vm.hostname = "bazinga.box"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/generic-alpine39.rb
+++ b/tpl/generic-alpine39.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "generic/bazinga"
-  # config.vm.hostname = "bazinga.box"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/generic-arch.rb
+++ b/tpl/generic-arch.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "generic/bazinga"
-  # config.vm.hostname = "bazinga.box"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/generic-centos6.rb
+++ b/tpl/generic-centos6.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "generic/bazinga"
-  # config.vm.hostname = "bazinga.box"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/generic-centos7.rb
+++ b/tpl/generic-centos7.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "generic/bazinga"
-  # config.vm.hostname = "bazinga.box"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/generic-centos8.rb
+++ b/tpl/generic-centos8.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "generic/bazinga"
-  # config.vm.hostname = "bazinga.box"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/generic-debian10.rb
+++ b/tpl/generic-debian10.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "generic/bazinga"
-  # config.vm.hostname = "bazinga.box"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/generic-debian8.rb
+++ b/tpl/generic-debian8.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "generic/bazinga"
-  # config.vm.hostname = "bazinga.box"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/generic-debian9.rb
+++ b/tpl/generic-debian9.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "generic/bazinga"
-  # config.vm.hostname = "bazinga.box"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/generic-default.rb
+++ b/tpl/generic-default.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "generic/bazinga"
-  # config.vm.hostname = "bazinga.box"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/generic-dragonflybsd5.rb
+++ b/tpl/generic-dragonflybsd5.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "generic/bazinga"
-  # config.vm.hostname = "bazinga.box"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/generic-fedora25.rb
+++ b/tpl/generic-fedora25.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "generic/bazinga"
-  # config.vm.hostname = "bazinga.box"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/generic-fedora26.rb
+++ b/tpl/generic-fedora26.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "generic/bazinga"
-  # config.vm.hostname = "bazinga.box"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/generic-fedora27.rb
+++ b/tpl/generic-fedora27.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "generic/bazinga"
-  # config.vm.hostname = "bazinga.box"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/generic-fedora28.rb
+++ b/tpl/generic-fedora28.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "generic/bazinga"
-  # config.vm.hostname = "bazinga.box"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/generic-fedora29.rb
+++ b/tpl/generic-fedora29.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "generic/bazinga"
-  # config.vm.hostname = "bazinga.box"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/generic-fedora30.rb
+++ b/tpl/generic-fedora30.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "generic/bazinga"
-  # config.vm.hostname = "bazinga.box"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/generic-fedora31.rb
+++ b/tpl/generic-fedora31.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "generic/bazinga"
-  # config.vm.hostname = "bazinga.box"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/generic-freebsd11.rb
+++ b/tpl/generic-freebsd11.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "generic/bazinga"
-  # config.vm.hostname = "bazinga.box"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/generic-freebsd12.rb
+++ b/tpl/generic-freebsd12.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "generic/bazinga"
-  # config.vm.hostname = "bazinga.box"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/generic-gentoo.rb
+++ b/tpl/generic-gentoo.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "generic/bazinga"
-  # config.vm.hostname = "bazinga.box"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/generic-hardenedbsd11.rb
+++ b/tpl/generic-hardenedbsd11.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "generic/bazinga"
-  # config.vm.hostname = "bazinga.box"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/generic-hardenedbsd12.rb
+++ b/tpl/generic-hardenedbsd12.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "generic/bazinga"
-  # config.vm.hostname = "bazinga.box"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/generic-netbsd8.rb
+++ b/tpl/generic-netbsd8.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "generic/bazinga"
-  # config.vm.hostname = "bazinga.box"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/generic-openbsd6.rb
+++ b/tpl/generic-openbsd6.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "generic/bazinga"
-  # config.vm.hostname = "bazinga.box"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/generic-opensuse15.rb
+++ b/tpl/generic-opensuse15.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "generic/bazinga"
-  # config.vm.hostname = "bazinga.box"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/generic-opensuse42.rb
+++ b/tpl/generic-opensuse42.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "generic/bazinga"
-  # config.vm.hostname = "bazinga.box"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/generic-oracle7.rb
+++ b/tpl/generic-oracle7.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "generic/bazinga"
-  # config.vm.hostname = "bazinga.box"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/generic-oracle8.rb
+++ b/tpl/generic-oracle8.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "generic/bazinga"
-  # config.vm.hostname = "bazinga.box"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/generic-rhel6.rb
+++ b/tpl/generic-rhel6.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "generic/bazinga"
-  # config.vm.hostname = "bazinga.box"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/generic-rhel7.rb
+++ b/tpl/generic-rhel7.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "generic/bazinga"
-  # config.vm.hostname = "bazinga.box"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/generic-rhel8.rb
+++ b/tpl/generic-rhel8.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "generic/bazinga"
-  # config.vm.hostname = "bazinga.box"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/generic-ubuntu1604.rb
+++ b/tpl/generic-ubuntu1604.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "generic/bazinga"
-  # config.vm.hostname = "bazinga.box"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/generic-ubuntu1610.rb
+++ b/tpl/generic-ubuntu1610.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "generic/bazinga"
-  # config.vm.hostname = "bazinga.box"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/generic-ubuntu1704.rb
+++ b/tpl/generic-ubuntu1704.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "generic/bazinga"
-  # config.vm.hostname = "bazinga.box"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/generic-ubuntu1710.rb
+++ b/tpl/generic-ubuntu1710.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "generic/bazinga"
-  # config.vm.hostname = "bazinga.box"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/generic-ubuntu1804.rb
+++ b/tpl/generic-ubuntu1804.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "generic/bazinga"
-  # config.vm.hostname = "bazinga.box"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/generic-ubuntu1810.rb
+++ b/tpl/generic-ubuntu1810.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "generic/bazinga"
-  # config.vm.hostname = "bazinga.box"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/generic-ubuntu1904.rb
+++ b/tpl/generic-ubuntu1904.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "generic/bazinga"
-  # config.vm.hostname = "bazinga.box"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/generic-ubuntu1910.rb
+++ b/tpl/generic-ubuntu1910.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "generic/bazinga"
-  # config.vm.hostname = "bazinga.box"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/roboxes-alpine310.rb
+++ b/tpl/roboxes-alpine310.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "roboxes/bazinga"
-  # config.vm.hostname = "bazinga.roboxes"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/roboxes-alpine35.rb
+++ b/tpl/roboxes-alpine35.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "roboxes/bazinga"
-  # config.vm.hostname = "bazinga.roboxes"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/roboxes-alpine36.rb
+++ b/tpl/roboxes-alpine36.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "roboxes/bazinga"
-  # config.vm.hostname = "bazinga.roboxes"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/roboxes-alpine37.rb
+++ b/tpl/roboxes-alpine37.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "roboxes/bazinga"
-  # config.vm.hostname = "bazinga.roboxes"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/roboxes-alpine38.rb
+++ b/tpl/roboxes-alpine38.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "roboxes/bazinga"
-  # config.vm.hostname = "bazinga.roboxes"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/roboxes-alpine39.rb
+++ b/tpl/roboxes-alpine39.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "roboxes/bazinga"
-  # config.vm.hostname = "bazinga.roboxes"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/roboxes-arch.rb
+++ b/tpl/roboxes-arch.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "roboxes/bazinga"
-  # config.vm.hostname = "bazinga.roboxes"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/roboxes-centos6.rb
+++ b/tpl/roboxes-centos6.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "roboxes/bazinga"
-  # config.vm.hostname = "bazinga.roboxes"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/roboxes-centos7.rb
+++ b/tpl/roboxes-centos7.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "roboxes/bazinga"
-  # config.vm.hostname = "bazinga.roboxes"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/roboxes-centos8.rb
+++ b/tpl/roboxes-centos8.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "roboxes/bazinga"
-  # config.vm.hostname = "bazinga.roboxes"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/roboxes-debian10.rb
+++ b/tpl/roboxes-debian10.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "roboxes/bazinga"
-  # config.vm.hostname = "bazinga.roboxes"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/roboxes-debian8.rb
+++ b/tpl/roboxes-debian8.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "roboxes/bazinga"
-  # config.vm.hostname = "bazinga.roboxes"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/roboxes-debian9.rb
+++ b/tpl/roboxes-debian9.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "roboxes/bazinga"
-  # config.vm.hostname = "bazinga.roboxes"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/roboxes-default.rb
+++ b/tpl/roboxes-default.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "roboxes/bazinga"
-  # config.vm.hostname = "bazinga.roboxes"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/roboxes-dragonflybsd5.rb
+++ b/tpl/roboxes-dragonflybsd5.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "roboxes/bazinga"
-  # config.vm.hostname = "bazinga.roboxes"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/roboxes-fedora25.rb
+++ b/tpl/roboxes-fedora25.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "roboxes/bazinga"
-  # config.vm.hostname = "bazinga.roboxes"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/roboxes-fedora26.rb
+++ b/tpl/roboxes-fedora26.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "roboxes/bazinga"
-  # config.vm.hostname = "bazinga.roboxes"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/roboxes-fedora27.rb
+++ b/tpl/roboxes-fedora27.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "roboxes/bazinga"
-  # config.vm.hostname = "bazinga.roboxes"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/roboxes-fedora28.rb
+++ b/tpl/roboxes-fedora28.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "roboxes/bazinga"
-  # config.vm.hostname = "bazinga.roboxes"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/roboxes-fedora29.rb
+++ b/tpl/roboxes-fedora29.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "roboxes/bazinga"
-  # config.vm.hostname = "bazinga.roboxes"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/roboxes-fedora30.rb
+++ b/tpl/roboxes-fedora30.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "roboxes/bazinga"
-  # config.vm.hostname = "bazinga.roboxes"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/roboxes-fedora31.rb
+++ b/tpl/roboxes-fedora31.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "roboxes/bazinga"
-  # config.vm.hostname = "bazinga.roboxes"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/roboxes-freebsd11.rb
+++ b/tpl/roboxes-freebsd11.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "roboxes/bazinga"
-  # config.vm.hostname = "bazinga.roboxes"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/roboxes-freebsd12.rb
+++ b/tpl/roboxes-freebsd12.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "roboxes/bazinga"
-  # config.vm.hostname = "bazinga.roboxes"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/roboxes-gentoo.rb
+++ b/tpl/roboxes-gentoo.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "roboxes/bazinga"
-  # config.vm.hostname = "bazinga.roboxes"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/roboxes-hardenedbsd11.rb
+++ b/tpl/roboxes-hardenedbsd11.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "roboxes/bazinga"
-  # config.vm.hostname = "bazinga.roboxes"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/roboxes-hardenedbsd12.rb
+++ b/tpl/roboxes-hardenedbsd12.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "roboxes/bazinga"
-  # config.vm.hostname = "bazinga.roboxes"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/roboxes-netbsd8.rb
+++ b/tpl/roboxes-netbsd8.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "roboxes/bazinga"
-  # config.vm.hostname = "bazinga.roboxes"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/roboxes-openbsd6.rb
+++ b/tpl/roboxes-openbsd6.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "roboxes/bazinga"
-  # config.vm.hostname = "bazinga.roboxes"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/roboxes-opensuse15.rb
+++ b/tpl/roboxes-opensuse15.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "roboxes/bazinga"
-  # config.vm.hostname = "bazinga.roboxes"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/roboxes-opensuse42.rb
+++ b/tpl/roboxes-opensuse42.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "roboxes/bazinga"
-  # config.vm.hostname = "bazinga.roboxes"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/roboxes-oracle7.rb
+++ b/tpl/roboxes-oracle7.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "roboxes/bazinga"
-  # config.vm.hostname = "bazinga.roboxes"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/roboxes-oracle8.rb
+++ b/tpl/roboxes-oracle8.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "roboxes/bazinga"
-  # config.vm.hostname = "bazinga.roboxes"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/roboxes-rhel6.rb
+++ b/tpl/roboxes-rhel6.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "roboxes/bazinga"
-  # config.vm.hostname = "bazinga.roboxes"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/roboxes-rhel7.rb
+++ b/tpl/roboxes-rhel7.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "roboxes/bazinga"
-  # config.vm.hostname = "bazinga.roboxes"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/roboxes-rhel8.rb
+++ b/tpl/roboxes-rhel8.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "roboxes/bazinga"
-  # config.vm.hostname = "bazinga.roboxes"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/roboxes-ubuntu1604.rb
+++ b/tpl/roboxes-ubuntu1604.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "roboxes/bazinga"
-  # config.vm.hostname = "bazinga.roboxes"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/roboxes-ubuntu1610.rb
+++ b/tpl/roboxes-ubuntu1610.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "roboxes/bazinga"
-  # config.vm.hostname = "bazinga.roboxes"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/roboxes-ubuntu1704.rb
+++ b/tpl/roboxes-ubuntu1704.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "roboxes/bazinga"
-  # config.vm.hostname = "bazinga.roboxes"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/roboxes-ubuntu1710.rb
+++ b/tpl/roboxes-ubuntu1710.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "roboxes/bazinga"
-  # config.vm.hostname = "bazinga.roboxes"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/roboxes-ubuntu1804.rb
+++ b/tpl/roboxes-ubuntu1804.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "roboxes/bazinga"
-  # config.vm.hostname = "bazinga.roboxes"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/roboxes-ubuntu1810.rb
+++ b/tpl/roboxes-ubuntu1810.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "roboxes/bazinga"
-  # config.vm.hostname = "bazinga.roboxes"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/roboxes-ubuntu1904.rb
+++ b/tpl/roboxes-ubuntu1904.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "roboxes/bazinga"
-  # config.vm.hostname = "bazinga.roboxes"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true

--- a/tpl/roboxes-ubuntu1910.rb
+++ b/tpl/roboxes-ubuntu1910.rb
@@ -4,8 +4,6 @@
 Vagrant.configure(2) do |config|
 
   config.vm.boot_timeout = 1800
-  # config.vm.box = "roboxes/bazinga"
-  # config.vm.hostname = "bazinga.roboxes"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.box_check_update = true


### PR DESCRIPTION
The underlying issue was that some script commands were missing their environment variables, resulting in the default "bazinga" name for a few hostname.sh scripts.

While we're at it, remove the old bazinga override from the Vagrantfile templates.

Fixes: #124 