### PR TITLE
debian: Remove duplicated package repository

### DIFF
--- a/http/generic.debian10.vagrant.cfg
+++ b/http/generic.debian10.vagrant.cfg
@@ -54,6 +54,6 @@ d-i preseed/late_command string                                                 
         sed -i -e "s/.*PermitRootLogin.*/PermitRootLogin yes/g" /target/etc/ssh/sshd_config ; \
         dmesg | grep -E "Hypervisor detected: Microsoft HyperV|Hypervisor detected: Microsoft Hyper-V" ; \
         if [ $? -eq 0 ]; then \
-          chroot /target /bin/bash -c 'service ssh stop ; echo "deb http://deb.debian.org/debian buster main" >> /etc/apt/sources.list ; apt-get update ; apt-get install hyperv-daemons' ; \
+          chroot /target /bin/bash -c 'service ssh stop ; apt-get update ; apt-get install hyperv-daemons' ; \
         fi
 tasksel tasksel/first multiselect standard, server

--- a/http/generic.debian8.vagrant.cfg
+++ b/http/generic.debian8.vagrant.cfg
@@ -57,6 +57,6 @@ d-i preseed/late_command string                                                 
         sed -i -e "s/.*PermitRootLogin.*/PermitRootLogin yes/g" /target/etc/ssh/sshd_config ; \
         dmesg | grep -E "Hypervisor detected: Microsoft HyperV|Hypervisor detected: Microsoft Hyper-V" ; \
         if [ $? -eq 0 ]; then \
-          chroot /target /bin/bash -c 'service ssh stop ; echo "deb http://archive.debian.org/debian jessie main" >> /etc/apt/sources.list ; apt-get update ; apt-get install hyperv-daemons' ; \
+          chroot /target /bin/bash -c 'service ssh stop ; apt-get update ; apt-get install hyperv-daemons' ; \
         fi
 tasksel tasksel/first multiselect standard, server

--- a/http/generic.debian9.vagrant.cfg
+++ b/http/generic.debian9.vagrant.cfg
@@ -52,6 +52,6 @@ d-i preseed/late_command string                                                 
         sed -i -e "s/.*PermitRootLogin.*/PermitRootLogin yes/g" /target/etc/ssh/sshd_config ; \
         dmesg | grep -E "Hypervisor detected: Microsoft HyperV|Hypervisor detected: Microsoft Hyper-V" ; \
         if [ $? -eq 0 ]; then \
-          chroot /target /bin/bash -c 'service ssh stop ; echo "deb http://deb.debian.org/debian stretch main" >> /etc/apt/sources.list ; apt-get update ; apt-get install hyperv-daemons' ; \
+          chroot /target /bin/bash -c 'service ssh stop ; apt-get update ; apt-get install hyperv-daemons' ; \
         fi
 tasksel tasksel/first multiselect standard, server


### PR DESCRIPTION
The additional repository line is undeeded. Confirmed by applying the patch, building the images and confirming that the `hyperv-daemons` package is still included.

Fixes: #126 