### PR TITLE
debian8: Don't use the archive.debian.org mirror

### DIFF
--- a/http/generic.debian8.vagrant.cfg
+++ b/http/generic.debian8.vagrant.cfg
@@ -1,9 +1,9 @@
 choose-mirror-bin mirror/http/proxy string
-d-i mirror/protocol string http
-d-i mirror/http/proxy string
-d-i mirror/country string manual
-d-i mirror/http/hostname string archive.debian.org
-d-i mirror/http/directory string /debian
+#d-i mirror/protocol string http
+#d-i mirror/http/proxy string
+#d-i mirror/country string manual
+#d-i mirror/http/hostname string archive.debian.org
+#d-i mirror/http/directory string /debian
 d-i base-installer/kernel/override-image string linux-server
 d-i keyboard-configuration/xkb-keymap select us
 d-i time/zone string US/Pacific


### PR DESCRIPTION
archive.debian.org is currently signing with expired keys.

Remove the explicit use of archive.debian.org (since the default server is still using working keys) until we really can't use it anymore.