### PR TITLE
Move Fedora and other RHEL-based images to virtio

### DIFF
--- a/tpl/generic-centos7.rb
+++ b/tpl/generic-centos7.rb
@@ -26,7 +26,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provider :libvirt do |v, override|
-    v.disk_bus = "scsi"
+    v.disk_bus = "virtio"
     v.driver = "kvm"
     v.video_vram = 256
     v.memory = 2048

--- a/tpl/generic-fedora25.rb
+++ b/tpl/generic-fedora25.rb
@@ -26,7 +26,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provider :libvirt do |v, override|
-    v.disk_bus = "scsi"
+    v.disk_bus = "virtio"
     v.driver = "kvm"
     v.video_vram = 256
     v.memory = 2048

--- a/tpl/generic-fedora26.rb
+++ b/tpl/generic-fedora26.rb
@@ -26,7 +26,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provider :libvirt do |v, override|
-    v.disk_bus = "scsi"
+    v.disk_bus = "virtio"
     v.driver = "kvm"
     v.video_vram = 256
     v.memory = 2048

--- a/tpl/generic-fedora27.rb
+++ b/tpl/generic-fedora27.rb
@@ -26,7 +26,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provider :libvirt do |v, override|
-    v.disk_bus = "scsi"
+    v.disk_bus = "virtio"
     v.driver = "kvm"
     v.video_vram = 256
     v.memory = 2048

--- a/tpl/generic-fedora28.rb
+++ b/tpl/generic-fedora28.rb
@@ -26,7 +26,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provider :libvirt do |v, override|
-    v.disk_bus = "scsi"
+    v.disk_bus = "virtio"
     v.driver = "kvm"
     v.video_vram = 256
     v.memory = 2048

--- a/tpl/generic-fedora29.rb
+++ b/tpl/generic-fedora29.rb
@@ -26,7 +26,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provider :libvirt do |v, override|
-    v.disk_bus = "scsi"
+    v.disk_bus = "virtio"
     v.driver = "kvm"
     v.video_vram = 256
     v.memory = 2048

--- a/tpl/generic-fedora30.rb
+++ b/tpl/generic-fedora30.rb
@@ -26,7 +26,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provider :libvirt do |v, override|
-    v.disk_bus = "scsi"
+    v.disk_bus = "virtio"
     v.driver = "kvm"
     v.video_vram = 256
     v.memory = 2048

--- a/tpl/generic-fedora31.rb
+++ b/tpl/generic-fedora31.rb
@@ -26,7 +26,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provider :libvirt do |v, override|
-    v.disk_bus = "scsi"
+    v.disk_bus = "virtio"
     v.driver = "kvm"
     v.video_vram = 256
     v.memory = 2048

--- a/tpl/generic-fedora32.rb
+++ b/tpl/generic-fedora32.rb
@@ -26,7 +26,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provider :libvirt do |v, override|
-    v.disk_bus = "scsi"
+    v.disk_bus = "virtio"
     v.driver = "kvm"
     v.video_vram = 256
     v.memory = 2048

--- a/tpl/generic-oracle7.rb
+++ b/tpl/generic-oracle7.rb
@@ -26,7 +26,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provider :libvirt do |v, override|
-    v.disk_bus = "scsi"
+    v.disk_bus = "virtio"
     v.driver = "kvm"
     v.video_vram = 256
     v.memory = 2048

--- a/tpl/generic-rhel7.rb
+++ b/tpl/generic-rhel7.rb
@@ -26,7 +26,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provider :libvirt do |v, override|
-    v.disk_bus = "scsi"
+    v.disk_bus = "virtio"
     v.driver = "kvm"
     v.video_vram = 256
     v.memory = 2048

--- a/tpl/roboxes-centos7.rb
+++ b/tpl/roboxes-centos7.rb
@@ -26,7 +26,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provider :libvirt do |v, override|
-    v.disk_bus = "scsi"
+    v.disk_bus = "virtio"
     v.driver = "kvm"
     v.video_vram = 256
     v.memory = 2048

--- a/tpl/roboxes-fedora25.rb
+++ b/tpl/roboxes-fedora25.rb
@@ -26,7 +26,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provider :libvirt do |v, override|
-    v.disk_bus = "scsi"
+    v.disk_bus = "virtio"
     v.driver = "kvm"
     v.video_vram = 256
     v.memory = 2048

--- a/tpl/roboxes-fedora26.rb
+++ b/tpl/roboxes-fedora26.rb
@@ -26,7 +26,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provider :libvirt do |v, override|
-    v.disk_bus = "scsi"
+    v.disk_bus = "virtio"
     v.driver = "kvm"
     v.video_vram = 256
     v.memory = 2048

--- a/tpl/roboxes-fedora27.rb
+++ b/tpl/roboxes-fedora27.rb
@@ -26,7 +26,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provider :libvirt do |v, override|
-    v.disk_bus = "scsi"
+    v.disk_bus = "virtio"
     v.driver = "kvm"
     v.video_vram = 256
     v.memory = 2048

--- a/tpl/roboxes-fedora28.rb
+++ b/tpl/roboxes-fedora28.rb
@@ -26,7 +26,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provider :libvirt do |v, override|
-    v.disk_bus = "scsi"
+    v.disk_bus = "virtio"
     v.driver = "kvm"
     v.video_vram = 256
     v.memory = 2048

--- a/tpl/roboxes-fedora29.rb
+++ b/tpl/roboxes-fedora29.rb
@@ -26,7 +26,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provider :libvirt do |v, override|
-    v.disk_bus = "scsi"
+    v.disk_bus = "virtio"
     v.driver = "kvm"
     v.video_vram = 256
     v.memory = 2048

--- a/tpl/roboxes-fedora30.rb
+++ b/tpl/roboxes-fedora30.rb
@@ -26,7 +26,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provider :libvirt do |v, override|
-    v.disk_bus = "scsi"
+    v.disk_bus = "virtio"
     v.driver = "kvm"
     v.video_vram = 256
     v.memory = 2048

--- a/tpl/roboxes-fedora31.rb
+++ b/tpl/roboxes-fedora31.rb
@@ -26,7 +26,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provider :libvirt do |v, override|
-    v.disk_bus = "scsi"
+    v.disk_bus = "virtio"
     v.driver = "kvm"
     v.video_vram = 256
     v.memory = 2048

--- a/tpl/roboxes-fedora32.rb
+++ b/tpl/roboxes-fedora32.rb
@@ -26,7 +26,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provider :libvirt do |v, override|
-    v.disk_bus = "scsi"
+    v.disk_bus = "virtio"
     v.driver = "kvm"
     v.video_vram = 256
     v.memory = 2048

--- a/tpl/roboxes-oracle7.rb
+++ b/tpl/roboxes-oracle7.rb
@@ -26,7 +26,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provider :libvirt do |v, override|
-    v.disk_bus = "scsi"
+    v.disk_bus = "virtio"
     v.driver = "kvm"
     v.video_vram = 256
     v.memory = 2048

--- a/tpl/roboxes-rhel7.rb
+++ b/tpl/roboxes-rhel7.rb
@@ -26,7 +26,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provider :libvirt do |v, override|
-    v.disk_bus = "scsi"
+    v.disk_bus = "virtio"
     v.driver = "kvm"
     v.video_vram = 256
     v.memory = 2048


### PR DESCRIPTION
This takes care of a lot of the non-booting boxes. All of those are fine with being built on virtio-scsi, but ultimately being run on pure virtio.

Only the generic boxes have been tested explicitly (built and tested on Manjaro).
The roboxes images only differ in the used Vagrantfile (which is usually the same anyways), so those should be fine as well.

I committed my changes seperately after building and testing each box, so feel free to squash.