### PR TITLE
alpine: Fix Vagrant versioning check

### DIFF
--- a/tpl/generic-alpine310.rb
+++ b/tpl/generic-alpine310.rb
@@ -31,7 +31,7 @@ Vagrant.configure(2) do |config|
     v.driver = "kvm"
     v.video_vram = 256
     v.disk_bus = "virtio"
-    if Vagrant::VERSION < '2.2.6' && !Vagrant.has_plugin?("vagrant-alpine")
+    if Vagrant.version?("< 2.2.6") && !Vagrant.has_plugin?("vagrant-alpine")
       override.trigger.before :up do |t|
         t.warn = "Setting OS type to 'ALT Linux' as a workaround, which might break guest OS specific features.\nPlease upgrade to Vagrant 2.2.6 or (if Vagrant can't be upgraded) install the 'vagrant-alpine' plugin if issues arise."
       end

--- a/tpl/generic-alpine311.rb
+++ b/tpl/generic-alpine311.rb
@@ -33,7 +33,7 @@ Vagrant.configure(2) do |config|
     v.driver = "kvm"
     v.video_vram = 256
     v.disk_bus = "virtio"
-    if Vagrant::VERSION < '2.2.6' && !Vagrant.has_plugin?("vagrant-alpine")
+    if Vagrant.version?("< 2.2.6") && !Vagrant.has_plugin?("vagrant-alpine")
       override.trigger.before :up do |t|
         t.warn = "Setting OS type to 'ALT Linux' as a workaround, which might break guest OS specific features.\nPlease upgrade to Vagrant 2.2.6 or (if Vagrant can't be upgraded) install the 'vagrant-alpine' plugin if issues arise."
       end

--- a/tpl/generic-alpine312.rb
+++ b/tpl/generic-alpine312.rb
@@ -33,7 +33,7 @@ Vagrant.configure(2) do |config|
     v.driver = "kvm"
     v.video_vram = 256
     v.disk_bus = "virtio"
-    if Vagrant::VERSION < '2.2.6' && !Vagrant.has_plugin?("vagrant-alpine")
+    if Vagrant.version?("< 2.2.6") && !Vagrant.has_plugin?("vagrant-alpine")
       override.trigger.before :up do |t|
         t.warn = "Setting OS type to 'ALT Linux' as a workaround, which might break guest OS specific features.\nPlease upgrade to Vagrant 2.2.6 or (if Vagrant can't be upgraded) install the 'vagrant-alpine' plugin if issues arise."
       end

--- a/tpl/generic-alpine35.rb
+++ b/tpl/generic-alpine35.rb
@@ -31,7 +31,7 @@ Vagrant.configure(2) do |config|
     v.driver = "kvm"
     v.video_vram = 256
     v.disk_bus = "scsi"
-    if Vagrant::VERSION < '2.2.6' && !Vagrant.has_plugin?("vagrant-alpine")
+    if Vagrant.version?("< 2.2.6") && !Vagrant.has_plugin?("vagrant-alpine")
       override.trigger.before :up do |t|
         t.warn = "Setting OS type to 'ALT Linux' as a workaround, which might break guest OS specific features.\nPlease upgrade to Vagrant 2.2.6 or (if Vagrant can't be upgraded) install the 'vagrant-alpine' plugin if issues arise."
       end

--- a/tpl/generic-alpine36.rb
+++ b/tpl/generic-alpine36.rb
@@ -31,7 +31,7 @@ Vagrant.configure(2) do |config|
     v.driver = "kvm"
     v.video_vram = 256
     v.disk_bus = "virtio"
-    if Vagrant::VERSION < '2.2.6' && !Vagrant.has_plugin?("vagrant-alpine")
+    if Vagrant.version?("< 2.2.6") && !Vagrant.has_plugin?("vagrant-alpine")
       override.trigger.before :up do |t|
         t.warn = "Setting OS type to 'ALT Linux' as a workaround, which might break guest OS specific features.\nPlease upgrade to Vagrant 2.2.6 or (if Vagrant can't be upgraded) install the 'vagrant-alpine' plugin if issues arise."
       end

--- a/tpl/generic-alpine37.rb
+++ b/tpl/generic-alpine37.rb
@@ -31,7 +31,7 @@ Vagrant.configure(2) do |config|
     v.driver = "kvm"
     v.video_vram = 256
     v.disk_bus = "virtio"
-    if Vagrant::VERSION < '2.2.6' && !Vagrant.has_plugin?("vagrant-alpine")
+    if Vagrant.version?("< 2.2.6") && !Vagrant.has_plugin?("vagrant-alpine")
       override.trigger.before :up do |t|
         t.warn = "Setting OS type to 'ALT Linux' as a workaround, which might break guest OS specific features.\nPlease upgrade to Vagrant 2.2.6 or (if Vagrant can't be upgraded) install the 'vagrant-alpine' plugin if issues arise."
       end

--- a/tpl/generic-alpine38.rb
+++ b/tpl/generic-alpine38.rb
@@ -31,7 +31,7 @@ Vagrant.configure(2) do |config|
     v.driver = "kvm"
     v.video_vram = 256
     v.disk_bus = "virtio"
-    if Vagrant::VERSION < '2.2.6' && !Vagrant.has_plugin?("vagrant-alpine")
+    if Vagrant.version?("< 2.2.6") && !Vagrant.has_plugin?("vagrant-alpine")
       override.trigger.before :up do |t|
         t.warn = "Setting OS type to 'ALT Linux' as a workaround, which might break guest OS specific features.\nPlease upgrade to Vagrant 2.2.6 or (if Vagrant can't be upgraded) install the 'vagrant-alpine' plugin if issues arise."
       end

--- a/tpl/generic-alpine39.rb
+++ b/tpl/generic-alpine39.rb
@@ -31,7 +31,7 @@ Vagrant.configure(2) do |config|
     v.driver = "kvm"
     v.video_vram = 256
     v.disk_bus = "virtio"
-    if Vagrant::VERSION < '2.2.6' && !Vagrant.has_plugin?("vagrant-alpine")
+    if Vagrant.version?("< 2.2.6") && !Vagrant.has_plugin?("vagrant-alpine")
       override.trigger.before :up do |t|
         t.warn = "Setting OS type to 'ALT Linux' as a workaround, which might break guest OS specific features.\nPlease upgrade to Vagrant 2.2.6 or (if Vagrant can't be upgraded) install the 'vagrant-alpine' plugin if issues arise."
       end

--- a/tpl/magma-alpine.rb
+++ b/tpl/magma-alpine.rb
@@ -107,7 +107,7 @@ Vagrant.configure(2) do |config|
     v.driver = "kvm"
     v.video_vram = 256
     v.disk_bus = "scsi"
-    if Vagrant::VERSION < '2.2.6' && !Vagrant.has_plugin?("vagrant-alpine")
+    if Vagrant.version?("< 2.2.6") && !Vagrant.has_plugin?("vagrant-alpine")
       override.trigger.before :up do |t|
         t.warn = "Setting OS type to 'ALT Linux' as a workaround, which might break guest OS specific features.\nPlease upgrade to Vagrant 2.2.6 or (if Vagrant can't be upgraded) install the 'vagrant-alpine' plugin if issues arise."
       end

--- a/tpl/roboxes-alpine310.rb
+++ b/tpl/roboxes-alpine310.rb
@@ -31,7 +31,7 @@ Vagrant.configure(2) do |config|
     v.driver = "kvm"
     v.video_vram = 256
     v.disk_bus = "virtio"
-    if Vagrant::VERSION < '2.2.6' && !Vagrant.has_plugin?("vagrant-alpine")
+    if Vagrant.version?("< 2.2.6") && !Vagrant.has_plugin?("vagrant-alpine")
       override.trigger.before :up do |t|
         t.warn = "Setting OS type to 'ALT Linux' as a workaround, which might break guest OS specific features.\nPlease upgrade to Vagrant 2.2.6 or (if Vagrant can't be upgraded) install the 'vagrant-alpine' plugin if issues arise."
       end

--- a/tpl/roboxes-alpine311.rb
+++ b/tpl/roboxes-alpine311.rb
@@ -33,7 +33,7 @@ Vagrant.configure(2) do |config|
     v.driver = "kvm"
     v.video_vram = 256
     v.disk_bus = "virtio"
-    if Vagrant::VERSION < '2.2.6' && !Vagrant.has_plugin?("vagrant-alpine")
+    if Vagrant.version?("< 2.2.6") && !Vagrant.has_plugin?("vagrant-alpine")
       override.trigger.before :up do |t|
         t.warn = "Setting OS type to 'ALT Linux' as a workaround, which might break guest OS specific features.\nPlease upgrade to Vagrant 2.2.6 or (if Vagrant can't be upgraded) install the 'vagrant-alpine' plugin if issues arise."
       end

--- a/tpl/roboxes-alpine312.rb
+++ b/tpl/roboxes-alpine312.rb
@@ -33,7 +33,7 @@ Vagrant.configure(2) do |config|
     v.driver = "kvm"
     v.video_vram = 256
     v.disk_bus = "virtio"
-    if Vagrant::VERSION < '2.2.6' && !Vagrant.has_plugin?("vagrant-alpine")
+    if Vagrant.version?("< 2.2.6") && !Vagrant.has_plugin?("vagrant-alpine")
       override.trigger.before :up do |t|
         t.warn = "Setting OS type to 'ALT Linux' as a workaround, which might break guest OS specific features.\nPlease upgrade to Vagrant 2.2.6 or (if Vagrant can't be upgraded) install the 'vagrant-alpine' plugin if issues arise."
       end

--- a/tpl/roboxes-alpine35.rb
+++ b/tpl/roboxes-alpine35.rb
@@ -31,7 +31,7 @@ Vagrant.configure(2) do |config|
     v.driver = "kvm"
     v.video_vram = 256
     v.disk_bus = "scsi"
-    if Vagrant::VERSION < '2.2.6' && !Vagrant.has_plugin?("vagrant-alpine")
+    if Vagrant.version?("< 2.2.6") && !Vagrant.has_plugin?("vagrant-alpine")
       override.trigger.before :up do |t|
         t.warn = "Setting OS type to 'ALT Linux' as a workaround, which might break guest OS specific features.\nPlease upgrade to Vagrant 2.2.6 or (if Vagrant can't be upgraded) install the 'vagrant-alpine' plugin if issues arise."
       end

--- a/tpl/roboxes-alpine36.rb
+++ b/tpl/roboxes-alpine36.rb
@@ -31,7 +31,7 @@ Vagrant.configure(2) do |config|
     v.driver = "kvm"
     v.video_vram = 256
     v.disk_bus = "virtio"
-    if Vagrant::VERSION < '2.2.6' && !Vagrant.has_plugin?("vagrant-alpine")
+    if Vagrant.version?("< 2.2.6") && !Vagrant.has_plugin?("vagrant-alpine")
       override.trigger.before :up do |t|
         t.warn = "Setting OS type to 'ALT Linux' as a workaround, which might break guest OS specific features.\nPlease upgrade to Vagrant 2.2.6 or (if Vagrant can't be upgraded) install the 'vagrant-alpine' plugin if issues arise."
       end

--- a/tpl/roboxes-alpine37.rb
+++ b/tpl/roboxes-alpine37.rb
@@ -31,7 +31,7 @@ Vagrant.configure(2) do |config|
     v.driver = "kvm"
     v.video_vram = 256
     v.disk_bus = "virtio"
-    if Vagrant::VERSION < '2.2.6' && !Vagrant.has_plugin?("vagrant-alpine")
+    if Vagrant.version?("< 2.2.6") && !Vagrant.has_plugin?("vagrant-alpine")
       override.trigger.before :up do |t|
         t.warn = "Setting OS type to 'ALT Linux' as a workaround, which might break guest OS specific features.\nPlease upgrade to Vagrant 2.2.6 or (if Vagrant can't be upgraded) install the 'vagrant-alpine' plugin if issues arise."
       end

--- a/tpl/roboxes-alpine38.rb
+++ b/tpl/roboxes-alpine38.rb
@@ -31,7 +31,7 @@ Vagrant.configure(2) do |config|
     v.driver = "kvm"
     v.video_vram = 256
     v.disk_bus = "virtio"
-    if Vagrant::VERSION < '2.2.6' && !Vagrant.has_plugin?("vagrant-alpine")
+    if Vagrant.version?("< 2.2.6") && !Vagrant.has_plugin?("vagrant-alpine")
       override.trigger.before :up do |t|
         t.warn = "Setting OS type to 'ALT Linux' as a workaround, which might break guest OS specific features.\nPlease upgrade to Vagrant 2.2.6 or (if Vagrant can't be upgraded) install the 'vagrant-alpine' plugin if issues arise."
       end

--- a/tpl/roboxes-alpine39.rb
+++ b/tpl/roboxes-alpine39.rb
@@ -31,7 +31,7 @@ Vagrant.configure(2) do |config|
     v.driver = "kvm"
     v.video_vram = 256
     v.disk_bus = "virtio"
-    if Vagrant::VERSION < '2.2.6' && !Vagrant.has_plugin?("vagrant-alpine")
+    if Vagrant.version?("< 2.2.6") && !Vagrant.has_plugin?("vagrant-alpine")
       override.trigger.before :up do |t|
         t.warn = "Setting OS type to 'ALT Linux' as a workaround, which might break guest OS specific features.\nPlease upgrade to Vagrant 2.2.6 or (if Vagrant can't be upgraded) install the 'vagrant-alpine' plugin if issues arise."
       end


### PR DESCRIPTION
The check right now does lexicographical (?) comparison, which results in `2.2.10` being treated as an earlier version than `2.2.6`.

Fix that by using the built-in `Vagrant.version?()` function for the version check.