### PR TITLE
Add Support for Ubuntu 20.10

### DIFF
--- a/generic-hyperv.json
+++ b/generic-hyperv.json
@@ -1512,6 +1512,38 @@
     {
       "type": "shell",
       "scripts": [
+        "scripts/ubuntu2010/apt.sh",
+        "scripts/ubuntu2010/network.sh"
+      ],
+      "start_retry_timeout": "45m",
+      "expect_disconnect": "true",
+      "only": [
+        "generic-ubuntu2010-hyperv"
+      ]
+    },
+    {
+      "type": "shell",
+      "scripts": [
+        "scripts/ubuntu2010/floppy.sh",
+        "scripts/ubuntu2010/vagrant.sh",
+        "scripts/ubuntu2010/motd.sh",
+        "scripts/ubuntu2010/fixtty.sh",
+        "scripts/ubuntu2010/virtualbox.sh",
+        "scripts/ubuntu2010/parallels.sh",
+        "scripts/ubuntu2010/vmware.sh",
+        "scripts/ubuntu2010/qemu.sh",
+        "scripts/ubuntu2010/cleanup.sh"
+      ],
+      "pause_before": "120s",
+      "start_retry_timeout": "45m",
+      "expect_disconnect": "true",
+      "only": [
+        "generic-ubuntu2010-hyperv"
+      ]
+    },
+    {
+      "type": "shell",
+      "scripts": [
         "scripts/fedora32/fixdns.sh",
         "scripts/fedora32/dnf.sh"
       ],
@@ -3589,6 +3621,58 @@
       "http_directory": "http",
       "iso_url": "http://cdimage.ubuntu.com/ubuntu-legacy-server/releases/20.04.1/release/ubuntu-20.04.1-legacy-server-amd64.iso",
       "iso_checksum": "f11bda2f2caed8f420802b59f382c25160b114ccc665dbac9c5046e7fceaced2",
+      "iso_checksum_type": "sha256",
+      "ssh_username": "root",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_timeout": "7200s",
+      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
+      "generation": 1,
+      "headless": true,
+      "communicator": "ssh",
+      "skip_compaction": false,
+      "enable_secure_boot": false,
+      "enable_mac_spoofing": false,
+      "enable_dynamic_memory": false,
+      "guest_additions_mode": "disable",
+      "enable_virtualization_extensions": false
+    },
+    {
+      "type": "hyperv-iso",
+      "name": "generic-ubuntu2010-hyperv",
+      "vm_name": "generic-ubuntu2010-hyperv",
+      "temp_path": "output/",
+      "output_directory": "output/generic-ubuntu2010-hyperv",
+      "boot_wait": "1s",
+      "boot_command": [
+        "<tab><wait><tab><wait><tab><wait><tab><wait>",
+        "<tab><wait><tab><wait><tab><wait><tab><wait>",
+        "<tab><wait><tab><wait><tab><wait><tab><wait>",
+        "<esc><f6><esc>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "/install/vmlinuz ",
+        "initrd=/install/initrd.gz ",
+        "fb=false ",
+        "auto-install/enable=true ",
+        "debconf/priority=critical ",
+        "console-setup/ask_detect=false ",
+        "debconf/frontend=noninteractive ",
+        "ipv6.disable_ipv6=1 net.ifnames=0 biosdevname=0 preseed/url=http://{{.HTTPIP}}:{{.HTTPPort}}/generic.ubuntu2010.vagrant.cfg<wait> ",
+        " --- <enter>"
+      ],
+      "disk_size": 131072,
+      "memory": 2048,
+      "cpus": 2,
+      "http_directory": "http",
+      "iso_url": "https://releases.ubuntu.com/20.10/ubuntu-20.10-live-server-amd64.iso",
+      "iso_checksum": "defdc1ad3af7b661fe2b4ee861fb6fdb5f52039389ef56da6efc05e6adfe3d45",
       "iso_checksum_type": "sha256",
       "ssh_username": "root",
       "ssh_password": "vagrant",

--- a/generic-libvirt.json
+++ b/generic-libvirt.json
@@ -1510,6 +1510,38 @@
       ]
     },
     {
+      "scripts": [
+        "scripts/ubuntu2010/apt.sh",
+        "scripts/ubuntu2010/network.sh"
+      ],
+      "type": "shell",
+      "start_retry_timeout": "15m",
+      "expect_disconnect": "true",
+      "only": [
+        "generic-ubuntu2010-libvirt"
+      ]
+    },
+    {
+      "scripts": [
+        "scripts/ubuntu2010/floppy.sh",
+        "scripts/ubuntu2010/vagrant.sh",
+        "scripts/ubuntu2010/motd.sh",
+        "scripts/ubuntu2010/fixtty.sh",
+        "scripts/ubuntu2010/virtualbox.sh",
+        "scripts/ubuntu2010/parallels.sh",
+        "scripts/ubuntu2010/vmware.sh",
+        "scripts/ubuntu2010/qemu.sh",
+        "scripts/ubuntu2010/cleanup.sh"
+      ],
+      "type": "shell",
+      "pause_before": "120s",
+      "start_retry_timeout": "15m",
+      "expect_disconnect": "true",
+      "only": [
+        "generic-ubuntu2010-libvirt"
+      ]
+    },
+    {
       "type": "shell",
       "scripts": [
         "scripts/fedora32/fixdns.sh",
@@ -3817,6 +3849,63 @@
       "headless": true,
       "iso_url": "http://cdimage.ubuntu.com/ubuntu-legacy-server/releases/20.04.1/release/ubuntu-20.04.1-legacy-server-amd64.iso",
       "iso_checksum": "f11bda2f2caed8f420802b59f382c25160b114ccc665dbac9c5046e7fceaced2",
+      "iso_checksum_type": "sha256",
+      "ssh_username": "root",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "3600s",
+      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now"
+    },
+    {
+      "type": "qemu",
+      "name": "generic-ubuntu2010-libvirt",
+      "vm_name": "generic-ubuntu2010-libvirt",
+      "output_directory": "output/generic-ubuntu2010-libvirt",
+      "accelerator": "kvm",
+      "qemu_binary": "/usr/libexec/qemu-kvm",
+      "boot_wait": "1s",
+      "boot_command": [
+        "<tab><wait><tab><wait><tab><wait><tab><wait>",
+        "<tab><wait><tab><wait><tab><wait><tab><wait>",
+        "<tab><wait><tab><wait><tab><wait><tab><wait>",
+        "<esc><f6><esc>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "/install/vmlinuz ",
+        "initrd=/install/initrd.gz ",
+        "fb=false ",
+        "auto-install/enable=true ",
+        "debconf/priority=critical ",
+        "console-setup/ask_detect=false ",
+        "debconf/frontend=noninteractive ",
+        "ipv6.disable_ipv6=1 net.ifnames=0 biosdevname=0 preseed/url=http://{{.HTTPIP}}:{{.HTTPPort}}/generic.ubuntu2010.vagrant.cfg<wait> ",
+        " --- <enter>"
+      ],
+      "format": "qcow2",
+      "disk_size": 131072,
+      "disk_discard": "unmap",
+      "disk_cache": "unsafe",
+      "disk_compression": true,
+      "disk_interface": "virtio-scsi",
+      "net_device": "virtio-net",
+      "cpus": 2,
+      "memory": 2048,
+      "qemuargs": [
+        [
+          "-drive",
+          "if=none,file=output/generic-ubuntu2010-libvirt/generic-ubuntu2010-libvirt,id=drive0,cache=unsafe,discard=unmap,detect-zeroes=unmap,format=qcow2"
+        ]
+      ],
+      "http_directory": "http",
+      "headless": true,
+      "iso_url": "https://releases.ubuntu.com/20.10/ubuntu-20.10-live-server-amd64.iso",
+      "iso_checksum": "defdc1ad3af7b661fe2b4ee861fb6fdb5f52039389ef56da6efc05e6adfe3d45",
       "iso_checksum_type": "sha256",
       "ssh_username": "root",
       "ssh_password": "vagrant",

--- a/generic-parallels.json
+++ b/generic-parallels.json
@@ -1510,6 +1510,38 @@
       ]
     },
     {
+      "scripts": [
+        "scripts/ubuntu2010/apt.sh",
+        "scripts/ubuntu2010/network.sh"
+      ],
+      "type": "shell",
+      "start_retry_timeout": "45m",
+      "expect_disconnect": "true",
+      "only": [
+        "generic-ubuntu2010-parallels"
+      ]
+    },
+    {
+      "scripts": [
+        "scripts/ubuntu2010/floppy.sh",
+        "scripts/ubuntu2010/vagrant.sh",
+        "scripts/ubuntu2010/motd.sh",
+        "scripts/ubuntu2010/fixtty.sh",
+        "scripts/ubuntu2010/virtualbox.sh",
+        "scripts/ubuntu2010/parallels.sh",
+        "scripts/ubuntu2010/vmware.sh",
+        "scripts/ubuntu2010/qemu.sh",
+        "scripts/ubuntu2010/cleanup.sh"
+      ],
+      "type": "shell",
+      "pause_before": "120s",
+      "start_retry_timeout": "45m",
+      "expect_disconnect": "true",
+      "only": [
+        "generic-ubuntu2010-parallels"
+      ]
+    },
+    {
       "type": "shell",
       "scripts": [
         "scripts/fedora32/fixdns.sh",
@@ -4939,6 +4971,87 @@
       "http_directory": "http",
       "iso_url": "http://cdimage.ubuntu.com/ubuntu-legacy-server/releases/20.04.1/release/ubuntu-20.04.1-legacy-server-amd64.iso",
       "iso_checksum": "f11bda2f2caed8f420802b59f382c25160b114ccc665dbac9c5046e7fceaced2",
+      "iso_checksum_type": "sha256",
+      "ssh_username": "root",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "3600s",
+      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
+      "parallels_tools_flavor": "lin",
+      "parallels_tools_mode": "upload",
+      "parallels_tools_guest_path": "/root/parallels-tools-linux.iso",
+      "prlctl_version_file": "/root/parallels-tools-version.txt"
+    },
+    {
+      "type": "parallels-iso",
+      "name": "generic-ubuntu2010-parallels",
+      "vm_name": "generic-ubuntu2010-parallels",
+      "output_directory": "output/generic-ubuntu2010-parallels",
+      "boot_wait": "1s",
+      "boot_command": [
+        "<tab><wait><tab><wait><tab><wait><tab><wait>",
+        "<tab><wait><tab><wait><tab><wait><tab><wait>",
+        "<tab><wait><tab><wait><tab><wait><tab><wait>",
+        "<esc><f6><esc>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "/install/vmlinuz ",
+        "initrd=/install/initrd.gz ",
+        "fb=false ",
+        "auto-install/enable=true ",
+        "debconf/priority=critical ",
+        "console-setup/ask_detect=false ",
+        "debconf/frontend=noninteractive ",
+        "ipv6.disable_ipv6=1 net.ifnames=0 biosdevname=0 preseed/url=http://{{.HTTPIP}}:{{.HTTPPort}}/generic.ubuntu2010.vagrant.cfg<wait> ",
+        " --- <enter>"
+      ],
+      "disk_size": 32768,
+      "cpus": 2,
+      "memory": 2048,
+      "prlctl": [
+        [
+          "set",
+          "{{.Name}}",
+          "--adaptive-hypervisor",
+          "on"
+        ],
+        [
+          "set",
+          "{{.Name}}",
+          "--3d-accelerate",
+          "off"
+        ],
+        [
+          "set",
+          "{{.Name}}",
+          "--videosize",
+          "16"
+        ],
+        [
+          "set",
+          "{{.Name}}",
+          "--pmu-virt",
+          "on"
+        ],
+        [
+          "set",
+          "{{.Name}}",
+          "--faster-vm",
+          "on"
+        ]
+      ],
+      "hard_drive_interface": "ide",
+      "guest_os_type": "ubuntu",
+      "skip_compaction": false,
+      "http_directory": "http",
+      "iso_url": "https://releases.ubuntu.com/20.10/ubuntu-20.10-live-server-amd64.iso",
+      "iso_checksum": "defdc1ad3af7b661fe2b4ee861fb6fdb5f52039389ef56da6efc05e6adfe3d45",
       "iso_checksum_type": "sha256",
       "ssh_username": "root",
       "ssh_password": "vagrant",

--- a/generic-virtualbox.json
+++ b/generic-virtualbox.json
@@ -1510,6 +1510,38 @@
       ]
     },
     {
+      "scripts": [
+        "scripts/ubuntu2010/apt.sh",
+        "scripts/ubuntu2010/network.sh"
+      ],
+      "type": "shell",
+      "start_retry_timeout": "15m",
+      "expect_disconnect": "true",
+      "only": [
+        "generic-ubuntu2010-virtualbox"
+      ]
+    },
+    {
+      "scripts": [
+        "scripts/ubuntu2010/floppy.sh",
+        "scripts/ubuntu2010/vagrant.sh",
+        "scripts/ubuntu2010/motd.sh",
+        "scripts/ubuntu2010/fixtty.sh",
+        "scripts/ubuntu2010/virtualbox.sh",
+        "scripts/ubuntu2010/parallels.sh",
+        "scripts/ubuntu2010/vmware.sh",
+        "scripts/ubuntu2010/qemu.sh",
+        "scripts/ubuntu2010/cleanup.sh"
+      ],
+      "type": "shell",
+      "pause_before": "120s",
+      "start_retry_timeout": "15m",
+      "expect_disconnect": "true",
+      "only": [
+        "generic-ubuntu2010-virtualbox"
+      ]
+    },
+    {
       "type": "shell",
       "scripts": [
         "scripts/fedora32/fixdns.sh",
@@ -3947,6 +3979,66 @@
       "vrdp_port_max": 12000,
       "iso_url": "http://cdimage.ubuntu.com/ubuntu-legacy-server/releases/20.04.1/release/ubuntu-20.04.1-legacy-server-amd64.iso",
       "iso_checksum": "f11bda2f2caed8f420802b59f382c25160b114ccc665dbac9c5046e7fceaced2",
+      "iso_checksum_type": "sha256",
+      "ssh_username": "root",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "3600s",
+      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
+      "guest_additions_url": "https://download.virtualbox.org/virtualbox/5.2.44/VBoxGuestAdditions_5.2.44.iso",
+      "guest_additions_sha256": "9883ee443a309f4ffa1d5dee2833f9e35ced598686c36d159f410e5edbac1ca4",
+      "guest_additions_path": "VBoxGuestAdditions.iso",
+      "guest_additions_mode": "upload",
+      "virtualbox_version_file": "VBoxVersion.txt"
+    },
+    {
+      "type": "virtualbox-iso",
+      "name": "generic-ubuntu2010-virtualbox",
+      "vm_name": "generic-ubuntu2010-virtualbox",
+      "output_directory": "output/generic-ubuntu2010-virtualbox",
+      "boot_wait": "1s",
+      "boot_command": [
+        "<tab><wait><tab><wait><tab><wait><tab><wait>",
+        "<tab><wait><tab><wait><tab><wait><tab><wait>",
+        "<tab><wait><tab><wait><tab><wait><tab><wait>",
+        "<esc><f6><esc>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "/install/vmlinuz ",
+        "initrd=/install/initrd.gz ",
+        "fb=false ",
+        "auto-install/enable=true ",
+        "debconf/priority=critical ",
+        "console-setup/ask_detect=false ",
+        "debconf/frontend=noninteractive ",
+        "ipv6.disable_ipv6=1 net.ifnames=0 biosdevname=0 preseed/url=http://{{.HTTPIP}}:{{.HTTPPort}}/generic.ubuntu2010.vagrant.cfg<wait> ",
+        " --- <enter>"
+      ],
+      "disk_size": 131072,
+      "cpus": 2,
+      "memory": 2048,
+      "vboxmanage": [
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--vram",
+          "64"
+        ]
+      ],
+      "guest_os_type": "Ubuntu_64",
+      "http_directory": "http",
+      "headless": true,
+      "vrdp_bind_address": "127.0.0.1",
+      "vrdp_port_min": 11000,
+      "vrdp_port_max": 12000,
+      "iso_url": "https://releases.ubuntu.com/20.10/ubuntu-20.10-live-server-amd64.iso",
+      "iso_checksum": "defdc1ad3af7b661fe2b4ee861fb6fdb5f52039389ef56da6efc05e6adfe3d45",
       "iso_checksum_type": "sha256",
       "ssh_username": "root",
       "ssh_password": "vagrant",

--- a/generic-vmware.json
+++ b/generic-vmware.json
@@ -1510,6 +1510,38 @@
       ]
     },
     {
+      "scripts": [
+        "scripts/ubuntu2010/apt.sh",
+        "scripts/ubuntu2010/network.sh"
+      ],
+      "type": "shell",
+      "start_retry_timeout": "15m",
+      "expect_disconnect": "true",
+      "only": [
+        "generic-ubuntu2010-vmware"
+      ]
+    },
+    {
+      "scripts": [
+        "scripts/ubuntu2010/floppy.sh",
+        "scripts/ubuntu2010/vagrant.sh",
+        "scripts/ubuntu2010/motd.sh",
+        "scripts/ubuntu2010/fixtty.sh",
+        "scripts/ubuntu2010/virtualbox.sh",
+        "scripts/ubuntu2010/parallels.sh",
+        "scripts/ubuntu2010/vmware.sh",
+        "scripts/ubuntu2010/qemu.sh",
+        "scripts/ubuntu2010/cleanup.sh"
+      ],
+      "type": "shell",
+      "pause_before": "120s",
+      "start_retry_timeout": "15m",
+      "expect_disconnect": "true",
+      "only": [
+        "generic-ubuntu2010-vmware"
+      ]
+    },
+    {
       "type": "shell",
       "scripts": [
         "scripts/fedora32/fixdns.sh",
@@ -4005,6 +4037,66 @@
       "vmx_remove_ethernet_interfaces": true,
       "iso_url": "http://cdimage.ubuntu.com/ubuntu-legacy-server/releases/20.04.1/release/ubuntu-20.04.1-legacy-server-amd64.iso",
       "iso_checksum": "f11bda2f2caed8f420802b59f382c25160b114ccc665dbac9c5046e7fceaced2",
+      "iso_checksum_type": "sha256",
+      "ssh_username": "root",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "3600s",
+      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
+      "tools_upload_flavor": "linux"
+    },
+    {
+      "type": "vmware-iso",
+      "name": "generic-ubuntu2010-vmware",
+      "vm_name": "generic-ubuntu2010-vmware",
+      "vmdk_name": "generic-ubuntu2010-vmware",
+      "output_directory": "output/generic-ubuntu2010-vmware",
+      "boot_wait": "1s",
+      "boot_command": [
+        "<tab><wait><tab><wait><tab><wait><tab><wait>",
+        "<tab><wait><tab><wait><tab><wait><tab><wait>",
+        "<tab><wait><tab><wait><tab><wait><tab><wait>",
+        "<esc><f6><esc>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "/install/vmlinuz ",
+        "initrd=/install/initrd.gz ",
+        "fb=false ",
+        "auto-install/enable=true ",
+        "debconf/priority=critical ",
+        "console-setup/ask_detect=false ",
+        "debconf/frontend=noninteractive ",
+        "ipv6.disable_ipv6=1 net.ifnames=0 biosdevname=0 preseed/url=http://{{.HTTPIP}}:{{.HTTPPort}}/generic.ubuntu2010.vagrant.cfg<wait> ",
+        " --- <enter>"
+      ],
+      "disk_size": 131072,
+      "disk_type_id": "0",
+      "cpus": 2,
+      "memory": 2048,
+      "version": "12",
+      "vmx_data_post": {
+        "virtualHW.version": "12",
+        "cleanShutdown": "TRUE",
+        "softPowerOff": "FALSE",
+        "ethernet0.virtualDev": "e1000",
+        "ethernet0.startConnected": "TRUE",
+        "ethernet0.wakeonpcktrcv": "false"
+      },
+      "guest_os_type": "ubuntu-64",
+      "skip_compaction": false,
+      "http_directory": "http",
+      "headless": true,
+      "vnc_disable_password": true,
+      "vnc_bind_address": "127.0.0.1",
+      "vmx_remove_ethernet_interfaces": true,
+      "iso_url": "https://releases.ubuntu.com/20.10/ubuntu-20.10-live-server-amd64.iso",
+      "iso_checksum": "defdc1ad3af7b661fe2b4ee861fb6fdb5f52039389ef56da6efc05e6adfe3d45",
       "iso_checksum_type": "sha256",
       "ssh_username": "root",
       "ssh_password": "vagrant",

--- a/http/generic.ubuntu2010.vagrant.cfg
+++ b/http/generic.ubuntu2010.vagrant.cfg
@@ -1,0 +1,69 @@
+d-i base-installer/kernel/override-image string linux-server
+d-i keyboard-configuration/xkb-keymap select us
+d-i time/zone string US/Pacific
+d-i debian-installer/locale string en_US.UTF-8
+d-i debian-installer/add-kernel-opts string net.ifnames=0 biosdevname=0
+d-i finish-install/reboot_in_progress note
+d-i grub-installer/bootdev string default
+d-i partman-auto/method string regular
+d-i partman-auto/expert_recipe string \
+        scheme ::                     \
+        512 0 512 ext4                \
+                $primary{ }           \
+                $bootable{ }          \
+                method{ format }      \
+                format{ }             \
+                use_filesystem{ }     \
+                filesystem{ ext4 }    \
+                mountpoint{ /boot } . \
+        200% 0 200% linux-swap        \
+                $primary{ }           \
+                method{ swap }        \
+                format{ } .           \
+        1 0 -1 ext4                   \
+                $primary{ }           \
+                method{ format }      \
+                format{ }             \
+                use_filesystem{ }     \
+                filesystem{ ext4 }    \
+                mountpoint{ / } .
+d-i partman-partitioning/confirm_write_new_label boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+d-i passwd/root-login boolean true
+d-i passwd/root-password password vagrant
+d-i passwd/root-password-again password vagrant
+d-i passwd/user-fullname string vagrant
+d-i passwd/user-uid string 1000
+d-i passwd/user-password password vagrant
+d-i passwd/user-password-again password vagrant
+d-i passwd/username string vagrant
+d-i user-setup/allow-password-weak boolean true
+d-i user-setup/encrypt-home boolean false
+d-i netcfg/hostname string ubuntu2010.localdomain
+
+tasksel tasksel/first multiselect standard, server
+d-i pkgsel/include string curl openssh-server sudo sed linux-tools-$(uname -r) linux-cloud-tools-$(uname -r)
+d-i pkgsel/install-language-support boolean false
+d-i pkgsel/language-packs multiselect en
+d-i pkgsel/update-policy select none
+d-i pkgsel/upgrade select full-upgrade
+
+d-i mirror/http/proxy string
+d-i mirror/country string manual
+d-i mirror/http/hostname string us.archive.ubuntu.com
+#d-i mirror/http/hostname string old-releases.ubuntu.com
+d-i mirror/http/directory string /ubuntu
+
+d-i apt-setup/security_host string security.ubuntu.com
+#d-i apt-setup/security_host string old-releases.ubuntu.com
+d-i apt-setup/security_path string /ubuntu
+
+# Add the following when the mirrors no longer support 20.04 updates.
+#; \
+#sed -i -e "s/security.ubuntu.com/old-releases.ubuntu.com/g" /target/etc/apt/sources.list ; \
+#sed -i -e "s/us.archive.ubuntu.com/old-releases.ubuntu.com/g" /target/etc/apt/sources.list
+
+d-i preseed/late_command string                                                   \
+  sed -i -e "s/.*PermitRootLogin.*/PermitRootLogin yes/g" /target/etc/ssh/sshd_config

--- a/packer-cache.json
+++ b/packer-cache.json
@@ -722,6 +722,22 @@
     },
     {
       "type": "vmware-iso",
+      "name": "ubuntu2010",
+      "output_directory": "output/ubuntu2010",
+      "headless": true,
+      "disk_size": 1,
+      "boot_wait": "5s",
+      "iso_url": "https://releases.ubuntu.com/20.10/ubuntu-20.10-live-server-amd64.iso",
+      "iso_checksum": "defdc1ad3af7b661fe2b4ee861fb6fdb5f52039389ef56da6efc05e6adfe3d45",
+      "iso_checksum_type": "sha256",
+      "ssh_username": "root",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10s",
+      "shutdown_command": "poweroff"
+    },
+    {
+      "type": "vmware-iso",
       "name": "fedora32",
       "output_directory": "output/fedora32",
       "headless": true,

--- a/scripts/ubuntu2010/apt.sh
+++ b/scripts/ubuntu2010/apt.sh
@@ -1,0 +1,91 @@
+#!/bin/bash -ex
+
+# If the TERM environment variable is missing, then tput may produce spurrious error messages.
+if [[ ! -n "$TERM" ]] || [[ "$TERM" -eq "dumb" ]]; then
+  export TERM="vt100"
+fi
+
+retry() {
+  local COUNT=1
+  local RESULT=0
+  while [[ "${COUNT}" -le 10 ]]; do
+    [[ "${RESULT}" -ne 0 ]] && {
+      [ "`which tput 2> /dev/null`" != "" ] && tput setaf 1
+      echo -e "\n${*} failed... retrying ${COUNT} of 10.\n" >&2
+      [ "`which tput 2> /dev/null`" != "" ] && tput sgr0
+    }
+    "${@}" && { RESULT=0 && break; } || RESULT="${?}"
+    COUNT="$((COUNT + 1))"
+
+    # Increase the delay with each iteration.
+    DELAY="$((DELAY + 10))"
+    sleep $DELAY
+  done
+
+  [[ "${COUNT}" -gt 10 ]] && {
+    [ "`which tput 2> /dev/null`" != "" ] && tput setaf 1
+    echo -e "\nThe command failed 10 times.\n" >&2
+    [ "`which tput 2> /dev/null`" != "" ] && tput sgr0
+  }
+
+  return "${RESULT}"
+}
+
+error() {
+        if [ $? -ne 0 ]; then
+                printf "\n\napt failed...\n\n";
+                exit 1
+        fi
+}
+
+# To allow for autmated installs, we disable interactive configuration steps.
+export DEBIAN_FRONTEND=noninteractive
+export DEBCONF_NONINTERACTIVE_SEEN=true
+
+# Temporarily disable IPv6, update the nameservers so packages download
+# properly. A more permanent soulution is applied by the network
+# configuration script.
+sysctl net.ipv6.conf.all.disable_ipv6=1
+printf "nameserver 4.2.2.1\nnameserver 4.2.2.2\nnameserver 208.67.220.220\n" > /etc/resolv.conf
+
+# Disable upgrades to new releases.
+sed -i -e 's/^Prompt=.*$/Prompt=never/' /etc/update-manager/release-upgrades;
+
+# If the apt configuration directory exists, we add our own config options.
+if [ -d /etc/apt/apt.conf.d/ ]; then
+
+# Disable periodic activities of apt.
+printf "APT::Periodic::Enable \"0\";\n" >> /etc/apt/apt.conf.d/10periodic
+
+# Enable retries, which should reduce the number box buld failures resulting from a temporal network problems.
+printf "APT::Periodic::Enable \"0\";\n" >> /etc/apt/apt.conf.d/20retries
+
+fi
+# Keep the daily apt updater from deadlocking our installs.
+systemctl stop apt-daily.service apt-daily.timer
+systemctl stop snapd.service snapd.socket
+
+# Update the package database.
+retry apt-get --assume-yes -o Dpkg::Options::="--force-confnew" update; error
+
+# Ensure the linux-tools and linux-cloud-tools get updated with the kernel.
+# retry apt-get --assume-yes -o Dpkg::Options::="--force-confnew" install linux-tools-generic linux-cloud-tools-generic
+
+# Upgrade the installed packages.
+retry apt-get --assume-yes -o Dpkg::Options::="--force-confnew" upgrade; error
+retry apt-get --assume-yes -o Dpkg::Options::="--force-confnew" dist-upgrade; error
+
+# Needed to retrieve source code, and other misc system tools.
+retry apt-get --assume-yes install vim vim-nox gawk git git-man liberror-perl wget curl rsync gnupg mlocate sysstat lsof pciutils usbutils lsb-release psmisc; error
+
+# Enable the sysstat collection service.
+sed -i -e "s|.*ENABLED=\".*\"|ENABLED=\"true\"|g" /etc/default/sysstat
+
+# Start the services we just added so the system will track its own performance.
+systemctl enable sysstat.service && systemctl start sysstat.service
+
+# Setup vim as the default editor.
+printf "alias vi=vim\n" >> /etc/profile.d/vim.sh
+
+# Populate the mlocate database during boot.
+printf "@reboot root command bash -c '/etc/cron.daily/mlocate'\n" > /etc/cron.d/mlocate

--- a/scripts/ubuntu2010/cleanup.sh
+++ b/scripts/ubuntu2010/cleanup.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+error() {
+  if [ $? -ne 0 ]; then
+    printf "\n\napt failed...\n\n";
+    exit 1
+  fi
+}
+
+# To allow for autmated installs, we disable interactive configuration steps.
+export DEBIAN_FRONTEND=noninteractive
+export DEBCONF_NONINTERACTIVE_SEEN=true
+
+# Keep the daily apt updater from deadlocking our installs.
+systemctl stop apt-daily.service apt-daily.timer
+systemctl stop snapd.service snapd.socket snapd.refresh.timer
+
+# Cleanup unused packages.
+apt-get --assume-yes autoremove; error
+apt-get --assume-yes autoclean; error
+
+# Clear the random seed.
+rm -f /var/lib/systemd/random-seed

--- a/scripts/ubuntu2010/fixtty.sh
+++ b/scripts/ubuntu2010/fixtty.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -eux
+
+# Fix the no tty bug with vagrant.
+# https://github.com/mitchellh/vagrant/issues/1673
+
+sed -i -e 's,^\(ACTIVE_CONSOLES="/dev/tty\).*,\11",' /etc/default/console-setup
+for f in /etc/init/tty[^1]*.conf; do
+  rm --force "$f"
+done

--- a/scripts/ubuntu2010/floppy.sh
+++ b/scripts/ubuntu2010/floppy.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -eux
+
+printf 'blacklist floppy\n' > /etc/modprobe.d/floppy.conf
+mkinitramfs -o /boot/initrd.img-$(uname -r) $(uname -r)
+

--- a/scripts/ubuntu2010/limits.sh
+++ b/scripts/ubuntu2010/limits.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -eux
+
+# Find out how much RAM is installed, and what 50% would be in KB.
+TOTALMEM=`free -k | grep -E "^Mem:" | awk -F' ' '{print $2}'`
+HALFMEM=`echo $(($TOTALMEM/2))`
+
+# Setup the memory locking limits.
+printf "*    soft    memlock    $HALFMEM\n" > /etc/security/limits.d/50-magmad.conf
+printf "*    hard    memlock    $HALFMEM\n" >> /etc/security/limits.d/50-magmad.conf

--- a/scripts/ubuntu2010/magma.sh
+++ b/scripts/ubuntu2010/magma.sh
@@ -1,0 +1,207 @@
+#!/bin/bash -eux
+
+retry() {
+  local COUNT=1
+  local RESULT=0
+  while [[ "${COUNT}" -le 10 ]]; do
+    [[ "${RESULT}" -ne 0 ]] && {
+      [ "`which tput 2> /dev/null`" != "" ] && tput setaf 1
+      echo -e "\\n${*} failed... retrying ${COUNT} of 10.\\n" >&2
+      [ "`which tput 2> /dev/null`" != "" ] && tput sgr0
+    }
+    "${@}" && { RESULT=0 && break; } || RESULT="${?}"
+    COUNT="$((COUNT + 1))"
+
+    # Increase the delay with each iteration.
+    DELAY="$((DELAY + 10))"
+    sleep $DELAY
+  done
+
+  [[ "${COUNT}" -gt 10 ]] && {
+    [ "`which tput 2> /dev/null`" != "" ] && tput setaf 1
+    echo -e "\\nThe command failed 10 times.\\n" >&2
+    [ "`which tput 2> /dev/null`" != "" ] && tput sgr0
+  }
+
+  return "${RESULT}"
+}
+
+# To allow for autmated installs, we disable interactive configuration steps.
+export DEBIAN_FRONTEND=noninteractive
+export DEBCONF_NONINTERACTIVE_SEEN=true
+
+# The packages needed to compile magma.
+retry apt-get --assume-yes install gcc g++ gcc-multilib make autoconf automake libtool flex bison gdb valgrind valgrind-dbg libpython2.7 libc6-dev libc++-dev libncurses5-dev libmpfr6 libmpfr-dev patch make cmake libarchive13 libbsd-dev libsubunit-dev libsubunit0 pkg-config
+
+# Need to retrieve the source code.
+retry apt-get --assume-yes install git git-man liberror-perl rsync wget
+
+# Needed to run the watcher and status scripts.
+retry apt-get --assume-yes install sysstat inotify-tools
+
+# Needed to run the stacie script.
+retry apt-get --assume-yes install python-crypto python-cryptography
+
+# Make sure the MySQLs server is available.
+retry apt-get --assume-yes install mysql-server
+
+# Force MySQL/MariaDB except the old fashioned '0000-00-00' date format.
+if [ -d /etc/mysql/mysql.conf.d/ ]; then
+  printf "[mysqld]\nsql-mode=allow_invalid_dates\n" >> /etc/mysql/mysql.conf.d/server-mode.cnf
+fi
+
+if [ -d /etc/mysql/mariadb.conf.d/ ]; then
+  printf "[mysqld]\nsql-mode=allow_invalid_dates\n" >> /etc/mysql/mariadb.conf.d/server-mode.cnf
+fi
+
+# Create the mytool user and grant the required permissions.
+mysql --execute="CREATE USER mytool@localhost IDENTIFIED BY 'aComplex1'"
+mysql --execute="GRANT ALL ON *.* TO mytool@localhost"
+
+# The postfix server for message relays.
+retry apt-get --assume-yes install postfix
+
+# Configure the postfix hostname and origin parameters.
+printf "\ninet_interfaces = localhost\n" >> /etc/postfix/main.cf
+printf "inet_protocols = ipv4\n" >> /etc/postfix/main.cf
+printf "myhostname = relay.magma.builder\n" >> /etc/postfix/main.cf
+printf "myorigin = magma.builder\n" >> /etc/postfix/main.cf
+printf "transport_maps = hash:/etc/postfix/transport\n" >> /etc/postfix/main.cf
+
+# Configure postfix to listen for relays on port 2525 so it doesn't conflict with magma.
+sed -i -e "s/^smtp\([ ]*inet\)/127.0.0.1:2525\1/" /etc/postfix/master.cf
+
+printf "\nmagma.builder         smtp:[127.0.0.1]:7000\n" >> /etc/postfix/transport
+printf "magmadaemon.com         smtp:[127.0.0.1]:7000\n" >> /etc/postfix/transport
+postmap /etc/postfix/transport
+
+# Setup the the box. This runs as root
+if [ -d /home/vagrant/ ]; then
+  OUTPUT="/home/vagrant/magma-build.sh"
+else
+  OUTPUT="/root/magma-build.sh"
+fi
+
+# Grab a snapshot of the development branch.
+cat <<-EOF > $OUTPUT
+#!/bin/bash
+
+error() {
+  if [ \$? -ne 0 ]; then
+    printf "\n\nmagma daemon compilation failed...\n\n";
+    exit 1
+  fi
+}
+
+if [ -x /usr/bin/id ]; then
+  ID=\`/usr/bin/id -u\`
+  if [ -n "\$ID" -a "\$ID" -eq 0 ]; then
+    systemctl start mariadb.service
+    systemctl start postfix.service
+    systemctl start memcached.service
+  fi
+fi
+
+# If the TERM environment variable is missing, then tput may trigger a fatal error.
+if [[ -n "$TERM" ]] && [[ "$TERM" -ne "dumb" ]]; then
+  export TPUT="tput"
+else
+  export TPUT="tput -Tvt100"
+fi
+
+# If the TERM environment variable is missing, then tput may trigger a fatal error.
+if [[ -n "$TERM" ]] && [[ "$TERM" -ne "dumb" ]]; then
+  export TPUT="tput"
+else
+  export TPUT="tput -Tvt100"
+fi
+
+# We need to give the box 30 seconds to get the networking setup or
+# the git clone operation will fail.
+sleep 30
+
+# Temporary [hopefully] workaround to avoid [yet another] bug in NSS.
+export NSS_DISABLE_HW_AES=1
+
+# If the directory is present, remove it so we can clone a fresh copy.
+if [ -d magma-develop ]; then
+  rm --recursive --force magma-develop
+fi
+
+# Clone the magma repository off Github.
+git clone https://github.com/lavabit/magma.git magma-develop; error
+cd magma-develop; error
+
+# Setup the bin links, just in case we need to troubleshoot things manually.
+dev/scripts/linkup.sh; error
+
+# Compile the dependencies into a shared library.
+dev/scripts/builders/build.lib.sh all; error
+
+# Reset the sandbox database and storage files.
+dev/scripts/database/schema.reset.sh; error
+
+# Enable the anti-virus engine and update the signatures.
+dev/scripts/freshen/freshen.clamav.sh 2>&1 | grep -v WARNING | grep -v PANIC; error
+sed -i -e "s/virus.available = false/virus.available = true/g" sandbox/etc/magma.sandbox.config
+
+# Ensure the sandbox config uses port 2525 for relays.
+sed -i -e "/magma.relay\[[0-9]*\].name.*/d" sandbox/etc/magma.sandbox.config
+sed -i -e "/magma.relay\[[0-9]*\].port.*/d" sandbox/etc/magma.sandbox.config
+sed -i -e "/magma.relay\[[0-9]*\].secure.*/d" sandbox/etc/magma.sandbox.config
+printf "\n\nmagma.relay[1].name = localhost\nmagma.relay[1].port = 2525\n\n" >> sandbox/etc/magma.sandbox.config
+
+# Bug fix... create the scan directory so ClamAV unit tests work.
+if [ ! -d 'sandbox/spool/scan/' ]; then
+  mkdir -p sandbox/spool/scan/
+fi
+
+# Compile the daemon and then compile the unit tests.
+make all; error
+
+# Change the socket path.
+sed -i -e "s/\/var\/lib\/mysql\/mysql.sock/\/var\/run\/mysqld\/mysqld.sock/g" sandbox/etc/magma.sandbox.config
+
+# Run the unit tests.
+dev/scripts/launch/check.run.sh
+
+# If the unit tests fail, print an error, but contine running.
+if [ \$? -ne 0 ]; then
+  \${TPUT} setaf 1; \${TPUT} bold; printf "\n\nsome of the magma daemon unit tests failed...\n\n"; \${TPUT} sgr0;
+  for i in 1 2 3; do
+    printf "\a"; sleep 1
+  done
+  sleep 12
+fi
+
+# Alternatively, run the unit tests atop Valgrind.
+# Note this takes awhile when the anti-virus engine is enabled.
+# dev/scripts/launch/check.vg
+
+# Daemonize instead of running on the console.
+# sed -i -e "s/magma.output.file = false/magma.output.file = true/g" sandbox/etc/magma.sandbox.config
+# sed -i -e "s/magma.system.daemonize = false/magma.system.daemonize = true/g" sandbox/etc/magma.sandbox.config
+
+# Launch the daemon.
+# ./magmad --config magma.system.daemonize=true sandbox/etc/magma.sandbox.config
+
+# Save the result.
+# RETVAL=\$?
+
+# Give the daemon time to start before exiting.
+sleep 15
+
+# Exit wit a zero so Vagrant doesn't think a failed unit test is a provision failure.
+exit \$RETVAL
+EOF
+
+# Make the script executable.
+if [ -d /home/vagrant/ ]; then
+  chown vagrant:vagrant /home/vagrant/magma-build.sh
+  chmod +x /home/vagrant/magma-build.sh
+else
+  chmod +x /root/magma-build.sh
+fi
+
+# Customize the message of the day
+printf "Magma Daemon Development Environment\nTo download and compile magma, just execute the magma-build.sh script.\n\n" > /etc/motd

--- a/scripts/ubuntu2010/memcached.sh
+++ b/scripts/ubuntu2010/memcached.sh
@@ -1,0 +1,42 @@
+#!/bin/bash -ex
+
+# If the TERM environment variable is missing, then tput may produce spurrious error messages.
+if [[ ! -n "$TERM" ]] || [[ "$TERM" -eq "dumb" ]]; then
+  export TERM="vt100"
+fi
+
+retry() {
+  local COUNT=1
+  local RESULT=0
+  while [[ "${COUNT}" -le 10 ]]; do
+    [[ "${RESULT}" -ne 0 ]] && {
+      [ "`which tput 2> /dev/null`" != "" ] && tput setaf 1
+      echo -e "\n${*} failed... retrying ${COUNT} of 10.\n" >&2
+      [ "`which tput 2> /dev/null`" != "" ] && tput sgr0
+    }
+    "${@}" && { RESULT=0 && break; } || RESULT="${?}"
+    COUNT="$((COUNT + 1))"
+
+    # Increase the delay with each iteration.
+    DELAY="$((DELAY + 10))"
+    sleep $DELAY
+  done
+
+  [[ "${COUNT}" -gt 10 ]] && {
+    [ "`which tput 2> /dev/null`" != "" ] && tput setaf 1
+    echo -e "\nThe command failed 10 times.\n" >&2
+    [ "`which tput 2> /dev/null`" != "" ] && tput sgr0
+  }
+
+  return "${RESULT}"
+}
+
+# To allow for autmated installs, we disable interactive configuration steps.
+export DEBIAN_FRONTEND=noninteractive
+export DEBCONF_NONINTERACTIVE_SEEN=true
+
+# The memcached server.
+retry apt-get --assume-yes install memcached libevent-dev
+
+# Setup memcached to start automatically.
+systemctl start memcached.service && systemctl enable memcached.service

--- a/scripts/ubuntu2010/motd.sh
+++ b/scripts/ubuntu2010/motd.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -eux
+
+sed -i -e "s/motd=\/run\/motd.dynamic/motd=\/etc\/motd/g" /etc/pam.d/sshd
+sed -i -e "s/\(.*pam_motd.so.*noupdate.*\)/# \1/g" /etc/pam.d/sshd
+
+sed -i -e "s/motd=\/run\/motd.dynamic/motd=\/etc\/motd/g" /etc/pam.d/login
+sed -i -e "s/\(.*pam_motd.so.*noupdate.*\)/# \1/g" /etc/pam.d/login
+
+mkdir -p /root/.cache/
+touch /root/.cache/motd.legal-displayed
+
+if [ -d /home/vagrant/ ]; then
+  mkdir -p /home/vagrant/.cache/
+  touch /home/vagrant/.cache/motd.legal-displayed
+  chown vagrant:vagrant /home/vagrant/.cache/ 
+  chown vagrant:vagrant /home/vagrant/.cache/motd.legal-displayed
+fi
+
+cat <<-EOF > /etc/motd
+EOF

--- a/scripts/ubuntu2010/mysql.sh
+++ b/scripts/ubuntu2010/mysql.sh
@@ -1,0 +1,49 @@
+#!/bin/bash -ex
+
+# If the TERM environment variable is missing, then tput may produce spurrious error messages.
+if [[ ! -n "$TERM" ]] || [[ "$TERM" -eq "dumb" ]]; then
+  export TERM="vt100"
+fi
+
+retry() {
+  local COUNT=1
+  local RESULT=0
+  while [[ "${COUNT}" -le 10 ]]; do
+    [[ "${RESULT}" -ne 0 ]] && {
+      [ "`which tput 2> /dev/null`" != "" ] && tput setaf 1
+      echo -e "\n${*} failed... retrying ${COUNT} of 10.\n" >&2
+      [ "`which tput 2> /dev/null`" != "" ] && tput sgr0
+    }
+    "${@}" && { RESULT=0 && break; } || RESULT="${?}"
+    COUNT="$((COUNT + 1))"
+
+    # Increase the delay with each iteration.
+    DELAY="$((DELAY + 10))"
+    sleep $DELAY
+  done
+
+  [[ "${COUNT}" -gt 10 ]] && {
+    [ "`which tput 2> /dev/null`" != "" ] && tput setaf 1
+    echo -e "\nThe command failed 10 times.\n" >&2
+    [ "`which tput 2> /dev/null`" != "" ] && tput sgr0
+  }
+
+  return "${RESULT}"
+}
+
+# To allow for autmated installs, we disable interactive configuration steps.
+export DEBIAN_FRONTEND=noninteractive
+export DEBCONF_NONINTERACTIVE_SEEN=true
+
+# The mysql client and related utilities.
+retry apt-get --assume-yes install mysql-client mysql-server perl libdbi-perl libmysqlclient20 mysql-common libdbd-mysql-perl
+
+# Enable mysql and configure it to automatically start.
+systemctl start mysql.service && systemctl enable mysql.service
+
+# Setup the mysql root account with a random password.
+export PRAND=`openssl rand -base64 18`
+mysqladmin --user=root password "$PRAND"
+
+# Allow the root user to login to mysql as root by saving the randomly generated password.
+printf "\n\n[mysql]\nuser=root\npassword=$PRAND\n\n" >> /root/.my.cnf

--- a/scripts/ubuntu2010/network.sh
+++ b/scripts/ubuntu2010/network.sh
@@ -1,0 +1,86 @@
+#!/bin/bash -ex
+
+# If the TERM environment variable is missing, then tput may produce spurrious error messages.
+if [[ ! -n "$TERM" ]] || [[ "$TERM" -eq "dumb" ]]; then
+  export TERM="vt100"
+fi
+
+retry() {
+  local COUNT=1
+  local RESULT=0
+  while [[ "${COUNT}" -le 10 ]]; do
+    [[ "${RESULT}" -ne 0 ]] && {
+      [ "`which tput 2> /dev/null`" != "" ] && tput setaf 1
+      echo -e "\n${*} failed... retrying ${COUNT} of 10.\n" >&2
+      [ "`which tput 2> /dev/null`" != "" ] && tput sgr0
+    }
+    "${@}" && { RESULT=0 && break; } || RESULT="${?}"
+    COUNT="$((COUNT + 1))"
+
+    # Increase the delay with each iteration.
+    DELAY="$((DELAY + 10))"
+    sleep $DELAY
+  done
+
+  [[ "${COUNT}" -gt 10 ]] && {
+    [ "`which tput 2> /dev/null`" != "" ] && tput setaf 1
+    echo -e "\nThe command failed 10 times.\n" >&2
+    [ "`which tput 2> /dev/null`" != "" ] && tput sgr0
+  }
+
+  return "${RESULT}"
+}
+
+# Disable IPv6 for the current boot.
+sysctl net.ipv6.conf.all.disable_ipv6=1
+
+# Ensure IPv6 stays disabled.
+printf "\nnet.ipv6.conf.all.disable_ipv6 = 1\n" >> /etc/sysctl.conf
+
+# Set the hostname, and then ensure it will resolve properly.
+if [[ "$PACKER_BUILD_NAME" =~ ^generic-ubuntu2010-(vmware|hyperv|libvirt|parallels|virtualbox)$ ]]; then
+  printf "ubuntu2010.localdomain\n" > /etc/hostname
+  printf "\n127.0.0.1 ubuntu2010.localdomain\n\n" >> /etc/hosts
+else
+  printf "magma.builder\n" > /etc/hostname
+  printf "\n127.0.0.1 magma.builder\n\n" >> /etc/hosts
+fi
+
+cat <<-EOF > /etc/netplan/01-netcfg.yaml
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    eth0:
+      dhcp4: true
+      dhcp6: false
+      optional: true
+      nameservers:
+        addresses: [4.2.2.1, 4.2.2.2, 208.67.220.220]
+EOF
+
+# Apply the network plan configuration.
+netplan generate
+
+# Ensure a nameserver is being used that won't return an IP for non-existent domain names.
+sed -i -e "s/#DNS=.*/DNS=4.2.2.1 4.2.2.2 208.67.220.220/g" /etc/systemd/resolved.conf
+sed -i -e "s/#FallbackDNS=.*/FallbackDNS=/g" /etc/systemd/resolved.conf
+sed -i -e "s/#Domains=.*/Domains=/g" /etc/systemd/resolved.conf
+sed -i -e "s/#DNSSEC=.*/DNSSEC=yes/g" /etc/systemd/resolved.conf
+sed -i -e "s/#Cache=.*/Cache=yes/g" /etc/systemd/resolved.conf
+sed -i -e "s/#DNSStubListener=.*/DNSStubListener=yes/g" /etc/systemd/resolved.conf
+
+# Install ifplugd so we can monitor and auto-configure nics.
+retry apt-get --assume-yes install ifplugd
+
+# Configure ifplugd to monitor the eth0 interface.
+sed -i -e 's/INTERFACES=.*/INTERFACES="eth0"/g' /etc/default/ifplugd
+
+# Ensure the networking interfaces get configured on boot.
+systemctl enable systemd-networkd.service
+
+# Ensure ifplugd also gets started, so the ethernet interface is monitored.
+systemctl enable ifplugd.service
+
+# Reboot onto the new kernel (if applicable).
+$(shutdown -r +1) &

--- a/scripts/ubuntu2010/parallels.sh
+++ b/scripts/ubuntu2010/parallels.sh
@@ -1,0 +1,61 @@
+#!/bin/bash -ex
+
+# If the TERM environment variable is missing, then tput may produce spurrious error messages.
+if [[ ! -n "$TERM" ]] || [[ "$TERM" -eq "dumb" ]]; then
+  export TERM="vt100"
+fi
+
+retry() {
+  local COUNT=1
+  local RESULT=0
+  while [[ "${COUNT}" -le 10 ]]; do
+    [[ "${RESULT}" -ne 0 ]] && {
+      [ "`which tput 2> /dev/null`" != "" ] && tput setaf 1
+      echo -e "\n${*} failed... retrying ${COUNT} of 10.\n" >&2
+      [ "`which tput 2> /dev/null`" != "" ] && tput sgr0
+    }
+    "${@}" && { RESULT=0 && break; } || RESULT="${?}"
+    COUNT="$((COUNT + 1))"
+
+    # Increase the delay with each iteration.
+    DELAY="$((DELAY + 10))"
+    sleep $DELAY
+  done
+
+  [[ "${COUNT}" -gt 10 ]] && {
+    [ "`which tput 2> /dev/null`" != "" ] && tput setaf 1
+    echo -e "\nThe command failed 10 times.\n" >&2
+    [ "`which tput 2> /dev/null`" != "" ] && tput sgr0
+  }
+
+  return "${RESULT}"
+}
+
+# Needed to check whether we're running atop Parallels.
+export DEBIAN_FRONTEND=noninteractive
+export DEBCONF_NONINTERACTIVE_SEEN=true
+
+retry apt-get --assume-yes install dmidecode
+
+# Bail if we are not running atop Parallels.
+if [[ `dmidecode -s system-product-name` != "Parallels Virtual Platform" ]]; then
+    exit 0
+fi
+
+# Read in the version number.
+PARALLELSVERSION=`cat /root/parallels-tools-version.txt`
+
+echo "Installing the Parallels tools, version $PARALLELSVERSION."
+
+mkdir -p /mnt/parallels/
+mount -o loop /root/parallels-tools-linux.iso /mnt/parallels/
+
+/mnt/parallels/install --install-unattended-with-deps --verbose --progress \
+  || (status="$?" ; echo "Parallels tools installation failed. Error: $status" ; cat /var/log/parallels-tools-install.log ; exit $status)
+
+umount /mnt/parallels/
+rmdir /mnt/parallels/
+
+# Cleanup the guest additions.
+rm --force /root/parallels-tools-linux.iso
+rm --force /root/parallels-tools-version.txt

--- a/scripts/ubuntu2010/postfix.sh
+++ b/scripts/ubuntu2010/postfix.sh
@@ -1,0 +1,58 @@
+#!/bin/bash -ex
+
+# If the TERM environment variable is missing, then tput may produce spurrious error messages.
+if [[ ! -n "$TERM" ]] || [[ "$TERM" -eq "dumb" ]]; then
+  export TERM="vt100"
+fi
+
+retry() {
+  local COUNT=1
+  local RESULT=0
+  while [[ "${COUNT}" -le 10 ]]; do
+    [[ "${RESULT}" -ne 0 ]] && {
+      [ "`which tput 2> /dev/null`" != "" ] && tput setaf 1
+      echo -e "\n${*} failed... retrying ${COUNT} of 10.\n" >&2
+      [ "`which tput 2> /dev/null`" != "" ] && tput sgr0
+    }
+    "${@}" && { RESULT=0 && break; } || RESULT="${?}"
+    COUNT="$((COUNT + 1))"
+
+    # Increase the delay with each iteration.
+    DELAY="$((DELAY + 10))"
+    sleep $DELAY
+  done
+
+  [[ "${COUNT}" -gt 10 ]] && {
+    [ "`which tput 2> /dev/null`" != "" ] && tput setaf 1
+    echo -e "\nThe command failed 10 times.\n" >&2
+    [ "`which tput 2> /dev/null`" != "" ] && tput sgr0
+  }
+
+  return "${RESULT}"
+}
+
+# To allow for autmated installs, we disable interactive configuration steps.
+export DEBIAN_FRONTEND=noninteractive
+export DEBCONF_NONINTERACTIVE_SEEN=true
+
+# The postfix server for message relays.
+retry apt-get --assume-yes install postfix postfix-cdb libcdb1 ssl-cert
+
+# Configure postfix to listen for relays on port 2525 so it doesn't conflict with magma.
+sed -i -e "s/^smtp\([ ]*inet\)/127.0.0.1:2525\1/" /etc/postfix/master.cf
+
+# Copy over the default debian postfix config file.
+cp /usr/share/postfix/main.cf.debian /etc/postfix/main.cf
+
+# Configure the postfix hostname and origin parameters.
+printf "\ninet_interfaces = localhost\n" >> /etc/postfix/main.cf
+printf "inet_protocols = ipv4\n" >> /etc/postfix/main.cf
+printf "myhostname = relay.magma.builder\n" >> /etc/postfix/main.cf
+printf "myorigin = magma.builder\n" >> /etc/postfix/main.cf
+printf "transport_maps = hash:/etc/postfix/transport\n" >> /etc/postfix/main.cf
+
+# printf "magma.builder         smtp:[127.0.0.1]:7000\n" >> /etc/postfix/transport
+# postmap /etc/postfix/transport
+
+# So it gets started automatically.
+systemctl start postfix.service && systemctl enable postfix.service

--- a/scripts/ubuntu2010/qemu.sh
+++ b/scripts/ubuntu2010/qemu.sh
@@ -1,0 +1,63 @@
+#!/bin/bash -ex
+
+# If the TERM environment variable is missing, then tput may produce spurrious error messages.
+if [[ ! -n "$TERM" ]] || [[ "$TERM" -eq "dumb" ]]; then
+  export TERM="vt100"
+fi
+
+retry() {
+  local COUNT=1
+  local RESULT=0
+  while [[ "${COUNT}" -le 10 ]]; do
+    [[ "${RESULT}" -ne 0 ]] && {
+      [ "`which tput 2> /dev/null`" != "" ] && tput setaf 1
+      echo -e "\n${*} failed... retrying ${COUNT} of 10.\n" >&2
+      [ "`which tput 2> /dev/null`" != "" ] && tput sgr0
+    }
+    "${@}" && { RESULT=0 && break; } || RESULT="${?}"
+    COUNT="$((COUNT + 1))"
+
+    # Increase the delay with each iteration.
+    DELAY="$((DELAY + 10))"
+    sleep $DELAY
+  done
+
+  [[ "${COUNT}" -gt 10 ]] && {
+    [ "`which tput 2> /dev/null`" != "" ] && tput setaf 1
+    echo -e "\nThe command failed 10 times.\n" >&2
+    [ "`which tput 2> /dev/null`" != "" ] && tput sgr0
+  }
+
+  return "${RESULT}"
+}
+
+error() {
+        if [ $? -ne 0 ]; then
+                printf "\n\nqemu addons failed to install...\n\n";
+                exit 1
+        fi
+}
+
+
+# Bail if we are not running atop QEMU.
+if [[ `dmidecode -s system-product-name` != "KVM" && `dmidecode -s system-manufacturer` != "QEMU" ]]; then
+    exit 0
+fi
+
+# Install the QEMU using Yum.
+printf "Installing the QEMU Tools.\n"
+
+# To allow for autmated installs, we disable interactive configuration steps.
+export DEBIAN_FRONTEND=noninteractive
+export DEBCONF_NONINTERACTIVE_SEEN=true
+
+retry apt-get --assume-yes install qemu-guest-agent; error
+
+# For some reason the VMWare tools are installed on QEMU guest images.
+systemctl disable open-vm-tools.service
+
+# Boosts the available entropy which allows magma to start faster.
+retry apt-get --assume-yes install haveged; error
+
+# Autostart the haveged daemon.
+systemctl enable haveged.service

--- a/scripts/ubuntu2010/vagrant.sh
+++ b/scripts/ubuntu2010/vagrant.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -x
+
+# Create the vagrant user account.
+/usr/sbin/useradd vagrant
+
+# Enable exit/failure on error.
+set -eux
+
+printf "vagrant\nvagrant\n" | passwd vagrant
+sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
+printf "vagrant        ALL=(ALL)       NOPASSWD: ALL\n" > /etc/sudoers.d/vagrant
+chmod 0440 /etc/sudoers.d/vagrant
+
+# Create the vagrant user ssh directory.
+mkdir -pm 700 /home/vagrant/.ssh
+
+# Create an authorized keys file and insert the insecure public vagrant key.
+cat <<-EOF > /home/vagrant/.ssh/authorized_keys
+ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key
+EOF
+
+# Ensure the permissions are set correct to avoid OpenSSH complaints.
+chmod 0600 /home/vagrant/.ssh/authorized_keys
+chown -R vagrant:vagrant /home/vagrant/.ssh
+
+# Mark the vagrant box build time.
+date --utc > /etc/vagrant_box_build_time

--- a/scripts/ubuntu2010/virtualbox.sh
+++ b/scripts/ubuntu2010/virtualbox.sh
@@ -1,0 +1,82 @@
+#!/bin/bash -ex
+
+# If the TERM environment variable is missing, then tput may produce spurrious error messages.
+if [[ ! -n "$TERM" ]] || [[ "$TERM" -eq "dumb" ]]; then
+  export TERM="vt100"
+fi
+
+retry() {
+  local COUNT=1
+  local RESULT=0
+  while [[ "${COUNT}" -le 10 ]]; do
+    [[ "${RESULT}" -ne 0 ]] && {
+      [ "`which tput 2> /dev/null`" != "" ] && tput setaf 1
+      echo -e "\n${*} failed... retrying ${COUNT} of 10.\n" >&2
+      [ "`which tput 2> /dev/null`" != "" ] && tput sgr0
+    }
+    "${@}" && { RESULT=0 && break; } || RESULT="${?}"
+    COUNT="$((COUNT + 1))"
+
+    # Increase the delay with each iteration.
+    DELAY="$((DELAY + 10))"
+    sleep $DELAY
+  done
+
+  [[ "${COUNT}" -gt 10 ]] && {
+    [ "`which tput 2> /dev/null`" != "" ] && tput setaf 1
+    echo -e "\nThe command failed 10 times.\n" >&2
+    [ "`which tput 2> /dev/null`" != "" ] && tput sgr0
+  }
+
+  return "${RESULT}"
+}
+
+error() {
+  if [ $? -ne 0 ]; then
+    printf "\n\nThe VirtualBox install failed...\n\n"
+    exit 1
+  fi
+}
+
+# Bail if we are not running atop VirtualBox.
+if [[ `dmidecode -s system-product-name` != "VirtualBox" ]]; then
+    exit 0
+fi
+
+# Install the Virtual Box Tools from the Linux Guest Additions ISO.
+printf "Installing the Virtual Box Tools.\n"
+
+# To allow for autmated installs, we disable interactive configuration steps.
+export DEBIAN_FRONTEND=noninteractive
+export DEBCONF_NONINTERACTIVE_SEEN=true
+
+retry apt-get --assume-yes install virtualbox-guest-utils; error
+
+# Read in the version number.
+export VBOXVERSION=`cat /root/VBoxVersion.txt`
+
+# export DEBIAN_FRONTEND=noninteractive
+# export DEBCONF_NONINTERACTIVE_SEEN=true
+# apt-get --assume-yes install dkms build-essential module-assistant linux-headers-$(uname -r); error
+#
+# # The group vboxsf is needed for shared folder access.
+# getent group vboxsf >/dev/null || groupadd --system vboxsf; error
+# getent passwd vboxadd >/dev/null || useradd --system --gid bin --home-dir /var/run/vboxadd --shell /sbin/nologin vboxadd; error
+#
+# mkdir -p /mnt/virtualbox; error
+# mount -o loop /root/VBoxGuestAdditions.iso /mnt/virtualbox; error
+#
+# # For some reason the vboxsf module fails the first time, but installs
+# # successfully if we run the installer a second time.
+# sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11 || sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11; error
+# ln -s /opt/VBoxGuestAdditions-$VBOXVERSION/lib/VBoxGuestAdditions /usr/lib/VBoxGuestAdditions; error
+#
+# umount /mnt/virtualbox; error
+rm -rf /root/VBoxVersion.txt; error
+rm -rf /root/VBoxGuestAdditions.iso; error
+
+# Boosts the available entropy which allows magma to start faster.
+retry apt-get --assume-yes install haveged; error
+
+# Autostart the haveged daemon.
+systemctl enable haveged.service

--- a/scripts/ubuntu2010/vmware.sh
+++ b/scripts/ubuntu2010/vmware.sh
@@ -1,0 +1,77 @@
+#!/bin/bash -ex
+
+# If the TERM environment variable is missing, then tput may produce spurrious error messages.
+if [[ ! -n "$TERM" ]] || [[ "$TERM" -eq "dumb" ]]; then
+  export TERM="vt100"
+fi
+
+retry() {
+  local COUNT=1
+  local RESULT=0
+  while [[ "${COUNT}" -le 10 ]]; do
+    [[ "${RESULT}" -ne 0 ]] && {
+      [ "`which tput 2> /dev/null`" != "" ] && tput setaf 1
+      echo -e "\n${*} failed... retrying ${COUNT} of 10.\n" >&2
+      [ "`which tput 2> /dev/null`" != "" ] && tput sgr0
+    }
+    "${@}" && { RESULT=0 && break; } || RESULT="${?}"
+    COUNT="$((COUNT + 1))"
+
+    # Increase the delay with each iteration.
+    DELAY="$((DELAY + 10))"
+    sleep $DELAY
+  done
+
+  [[ "${COUNT}" -gt 10 ]] && {
+    [ "`which tput 2> /dev/null`" != "" ] && tput setaf 1
+    echo -e "\nThe command failed 10 times.\n" >&2
+    [ "`which tput 2> /dev/null`" != "" ] && tput sgr0
+  }
+
+  return "${RESULT}"
+}
+
+error() {
+        if [ $? -ne 0 ]; then
+                printf "\n\nvmware install failed...\n\n";
+                exit 1
+        fi
+}
+
+
+# Bail if we are not running inside VMWare.
+if [[ `dmidecode -s system-product-name` != "VMware Virtual Platform" ]]; then
+    exit 0
+fi
+
+# Install the VMWare Tools from the Linux ISO.
+printf "Installing the VMWare Tools.\n"
+
+# To allow for autmated installs, we disable interactive configuration steps.
+export DEBIAN_FRONTEND=noninteractive
+export DEBCONF_NONINTERACTIVE_SEEN=true
+
+retry apt-get --assume-yes install open-vm-tools ethtool libdumbnet1 zerofree
+systemctl enable open-vm-tools.service
+systemctl start open-vm-tools.service
+
+#mkdir -p /mnt/vmware; error
+#mount -o loop /root/linux.iso /mnt/vmware; error
+
+#cd /tmp; error
+#tar xzf /mnt/vmware/VMwareTools-*.tar.gz; error
+
+#umount /mnt/vmware; error
+rm -rf /root/linux.iso; error
+
+#/tmp/vmware-tools-distrib/vmware-install.pl -d; error
+#rm -rf /tmp/vmware-tools-distrib; error
+
+# Boosts the available entropy which allows magma to start faster.
+retry apt-get --assume-yes install haveged; error
+
+# Autostart the haveged daemon.
+systemctl enable haveged.service
+
+# Fix the SSH NAT issue on VMWare systems.
+printf "\nIPQoS lowdelay throughput\n" >> /etc/ssh/sshd_config


### PR DESCRIPTION
Similar as https://github.com/lavabit/robox/pull/145 but using new https://releases.ubuntu.com/20.10/ubuntu-20.10-live-server-amd64.iso (because I couldn't find the `ubuntu-legacy-server` version).

P.S. Seems new live iso require a new automated server Installation procedure: 
- https://ubuntu.com/server/docs/install/autoinstall
- https://ubuntu.com/server/docs/install/autoinstall-quickstart
- https://ubuntu.com/server/docs/install/autoinstall-reference
- https://nickcharlton.net/posts/automating-ubuntu-2004-installs-with-packer.html