### PR TITLE
fedora33: `update-crypto-policies --set LEGACY`

### DIFF
--- a/scripts/fedora33/vagrant.sh
+++ b/scripts/fedora33/vagrant.sh
@@ -36,3 +36,7 @@ chown -R vagrant:vagrant /home/vagrant/.ssh
 
 # Mark the vagrant box build time.
 date --utc > /etc/vagrant_box_build_time
+
+# Ensures maximum compatibility with legacy systems (64-bit security).
+# https://github.com/hashicorp/vagrant/issues/11783#issuecomment-702100872
+update-crypto-policies --set LEGACY


### PR DESCRIPTION
Upstream SSH has been claiming for a few releases now that:

    It is now possible to perform chosen-prefix attacks against the
    SHA-1 algorithm for less than USD$50K. For this reason, we will be
    disabling the "ssh-rsa" public key signature algorithm by default in a
    near-future release.

Also see:
  - https://fedoraproject.org/wiki/Changes/StrongCryptoSettings2#Upgrade.2Fcompatibility_impact
  - https://gitlab.com/redhat-crypto/fedora-crypto-policies/-/commit/b298a9e1#49303b123e8d502a8711bccf3ba657fd55abe97c
  - https://github.com/hashicorp/vagrant/issues/11783#issuecomment-702100872
  - https://github.com/hashicorp/packer/issues/10074
  - https://github.com/containers/automation_images/pull/26#issuecomment-705780840