### PR TITLE
[Ubuntu 20.10] Bugfix `A start Job is running for sys-devices-virtual-mis-vmbus\x21hv_kvp.devices`

### DIFF
--- a/scripts/ubuntu2010/cleanup.sh
+++ b/scripts/ubuntu2010/cleanup.sh
@@ -15,6 +15,11 @@ export DEBCONF_NONINTERACTIVE_SEEN=true
 systemctl stop apt-daily.service apt-daily.timer
 systemctl stop snapd.service snapd.socket snapd.refresh.timer
 
+# KVP daemon fails to start on first boot of disco VM.
+# https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1820063
+# https://askubuntu.com/a/1204263
+systemctl disable hv-kvp-daemon.service
+
 # Cleanup unused packages.
 apt-get --assume-yes autoremove; error
 apt-get --assume-yes autoclean; error


### PR DESCRIPTION
See:

  - <https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1820063>
  - <https://askubuntu.com/a/1204263>