### PR TITLE
fedora33: `update-crypto-policies --set LEGACY`

### DIFF
--- a/scripts/fedora33/vagrant.sh
+++ b/scripts/fedora33/vagrant.sh
@@ -14,7 +14,8 @@ polkit.addRule(function(action, subject) {
     }
 });
 EOF
-chmod 0440 /etc/polkit-1/rules.d/49-vagrant.rules
+semanage fcontext -a -t etc_t /etc/polkit-1/rules.d/49-vagrant.rules
+chmod 0640 /etc/polkit-1/rules.d/49-vagrant.rules
 fi
 
 printf "vagrant\nvagrant\n" | passwd vagrant
@@ -42,7 +43,5 @@ cat <<-EOF > /etc/ssh/sshd_config.d/10-vagrant-insecure-rsa-key.conf
 # https://github.com/hashicorp/vagrant/issues/11783
 PubkeyAcceptedKeyTypes=+ssh-rsa
 EOF
-
-chcon system_u:object_r:etc_t:s0 /etc/ssh/sshd_config.d/10-vagrant-insecure-rsa-key.conf
-chmod 600 /etc/ssh/sshd_config.d/10-vagrant-insecure-rsa-key.conf
-
+semanage fcontext -a -t etc_t /etc/ssh/sshd_config.d/10-vagrant-insecure-rsa-key.conf
+chmod 0600 /etc/ssh/sshd_config.d/10-vagrant-insecure-rsa-key.conf


### PR DESCRIPTION
Follow up for https://github.com/lavabit/robox/pull/173, where both files are still missing during initial `vagrant up`:
  - `/etc/polkit-1/rules.d/49-vagrant.rules`
  - `/etc/ssh/sshd_config.d/10-vagrant-insecure-rsa-key.conf`

In case it is SELinux related, at least [`chcon`](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/selinux_users_and_administrators_guide/sect-security-enhanced_linux-working_with_selinux-selinux_contexts_labeling_files#sect-Security-Enhanced_Linux-SELinux_Contexts_Labeling_Files-Temporary_Changes_chcon) is just used for temporary changes but not as persistent as [`semanage fcontext`](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/selinux_users_and_administrators_guide/sect-security-enhanced_linux-working_with_selinux-selinux_contexts_labeling_files#sect-Security-Enhanced_Linux-SELinux_Contexts_Labeling_Files-Persistent_Changes_semanage_fcontext) should be.