### PR TITLE
opensuse: switch `mountby` to `uuid`

### DIFF
--- a/http/generic.opensuse15.vagrant.cfg
+++ b/http/generic.opensuse15.vagrant.cfg
@@ -57,7 +57,7 @@
           <fstopt>defaults</fstopt>
           <loop_fs config:type="boolean">false</loop_fs>
           <mount>swap</mount>
-          <mountby config:type="symbol">device</mountby>
+          <mountby config:type="symbol">uuid</mountby>
           <partition_id config:type="integer">130</partition_id>
           <partition_nr config:type="integer">1</partition_nr>
           <raid_options/>
@@ -71,7 +71,7 @@
           <format config:type="boolean">true</format>
           <loop_fs config:type="boolean">false</loop_fs>
           <mount>/</mount>
-          <mountby config:type="symbol">device</mountby>
+          <mountby config:type="symbol">uuid</mountby>
           <partition_id config:type="integer">131</partition_id>
           <partition_nr config:type="integer">2</partition_nr>
           <raid_options/>

--- a/http/generic.opensuse42.vagrant.cfg
+++ b/http/generic.opensuse42.vagrant.cfg
@@ -57,7 +57,7 @@
           <fstopt>defaults</fstopt>
           <loop_fs config:type="boolean">false</loop_fs>
           <mount>swap</mount>
-          <mountby config:type="symbol">device</mountby>
+          <mountby config:type="symbol">uuid</mountby>
           <partition_id config:type="integer">130</partition_id>
           <partition_nr config:type="integer">1</partition_nr>
           <raid_options/>
@@ -71,7 +71,7 @@
           <format config:type="boolean">true</format>
           <loop_fs config:type="boolean">false</loop_fs>
           <mount>/</mount>
-          <mountby config:type="symbol">device</mountby>
+          <mountby config:type="symbol">uuid</mountby>
           <partition_id config:type="integer">131</partition_id>
           <partition_nr config:type="integer">2</partition_nr>
           <raid_options/>


### PR DESCRIPTION
Switching `mountby` from `device` to `uuid` could improve the portability for switching `disk_bus` between `virtio-scsi` or `virtio` in Vagrantfile.