### PR TITLE
generic/opensuse15 exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ The following operating systems are on my personal list, but haven't been added 
 Manjaro  
 Mint  
 OpenSolaris  
-OpenSUSE Leap v15 (already building v42.3)  
 Slackware  
 
 MacOS  


### PR DESCRIPTION
and currently provides openSUSE Leap 15.2 yet