### PR TITLE
Extend the x32 boxes to Debian 8

### DIFF
--- a/generic-libvirt-x32.json
+++ b/generic-libvirt-x32.json
@@ -5,6 +5,40 @@
   "provisioners": [
     {
       "scripts": [
+        "scripts/debian8/apt.sh",
+        "scripts/debian8/network.sh"
+      ],
+      "type": "shell",
+      "timeout": "120m",
+      "start_retry_timeout": "15m",
+      "expect_disconnect": "true",
+      "only": [
+        "generic-debian8-x32-libvirt"
+      ]
+    },
+    {
+      "scripts": [
+        "scripts/debian8/floppy.sh",
+        "scripts/debian8/profile.sh",
+        "scripts/debian8/vagrant.sh",
+        "scripts/debian8/motd.sh",
+        "scripts/debian8/fixtty.sh",
+        "scripts/debian8/virtualbox.sh",
+        "scripts/debian8/parallels.sh",
+        "scripts/debian8/vmware.sh",
+        "scripts/debian8/qemu.sh"
+      ],
+      "type": "shell",
+      "timeout": "120m",
+      "pause_before": "120s",
+      "start_retry_timeout": "15m",
+      "expect_disconnect": "true",
+      "only": [
+        "generic-debian8-x32-libvirt"
+      ]
+    },
+    {
+      "scripts": [
         "scripts/debian9/apt.sh",
         "scripts/debian9/network.sh"
       ],
@@ -40,6 +74,50 @@
     }
   ],
   "builders": [
+    {
+      "type": "qemu",
+      "name": "generic-debian8-x32-libvirt",
+      "vm_name": "generic-debian8-x32-libvirt",
+      "output_directory": "output/generic-debian8-x32-libvirt",
+      "accelerator": "kvm",
+      "qemu_binary": "/usr/libexec/qemu-kvm",
+      "boot_wait": "10s",
+      "boot_command": [
+        "<esc><wait><esc><wait><esc><wait><esc><wait><esc><wait><esc><wait>",
+        "<esc><wait><esc><wait><esc><wait><esc><wait><esc><wait><esc><wait>",
+        "<esc><wait><esc><wait><esc><wait><esc><wait><esc><wait><esc><wait>",
+        "<esc><wait><esc><wait><esc><wait><esc><wait><esc><wait><esc><wait>",
+        "<esc><wait><esc><wait><esc><wait><esc><wait><esc><wait><esc><wait>",
+        "<esc><wait><esc><wait><esc><wait><esc><wait><esc><wait><esc><wait>",
+        "<esc><wait><esc><wait><esc><wait><esc><wait><esc><wait><esc><wait>",
+        "<esc><wait><esc><wait><esc><wait><esc><wait><esc><wait><esc><wait>",
+        "<esc><wait><esc><wait><esc><wait><esc><wait><esc><wait><esc><wait>",
+        "<esc><wait><esc><wait><esc><wait><esc><wait><esc><wait><esc><wait>",
+        "auto ",
+        "ipv6.disable_ipv6=1 net.ifnames=0 biosdevname=0 preseed/url=http://{{.HTTPIP}}:{{.HTTPPort}}/generic.debian8.vagrant.cfg ",
+        "<enter>"
+      ],
+      "format": "qcow2",
+      "disk_size": "131072",
+      "disk_discard": "unmap",
+      "disk_detect_zeroes": "unmap",
+      "disk_cache": "unsafe",
+      "disk_image": false,
+      "disk_compression": true,
+      "disk_interface": "virtio-scsi",
+      "net_device": "virtio-net",
+      "cpus": 2,
+      "memory": 2048,
+      "http_directory": "http",
+      "headless": true,
+      "iso_url": "https://cdimage.debian.org/cdimage/archive/8.11.1/i386/iso-cd/debian-8.11.1-i386-netinst.iso",
+      "iso_checksum": "sha256:3741a984d170770f433ef694c823227298f7e8a2ff9c6486dc0b466ef9f8e710",
+      "ssh_username": "root",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_timeout": "3600s",
+      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now"
+    },
     {
       "type": "qemu",
       "name": "generic-debian9-x32-libvirt",

--- a/generic-virtualbox-x32.json
+++ b/generic-virtualbox-x32.json
@@ -5,6 +5,40 @@
   "provisioners": [
     {
       "scripts": [
+        "scripts/debian8/apt.sh",
+        "scripts/debian8/network.sh"
+      ],
+      "type": "shell",
+      "timeout": "120m",
+      "start_retry_timeout": "15m",
+      "expect_disconnect": "true",
+      "only": [
+        "generic-debian8-x32-virtualbox"
+      ]
+    },
+    {
+      "scripts": [
+        "scripts/debian8/floppy.sh",
+        "scripts/debian8/profile.sh",
+        "scripts/debian8/vagrant.sh",
+        "scripts/debian8/motd.sh",
+        "scripts/debian8/fixtty.sh",
+        "scripts/debian8/virtualbox.sh",
+        "scripts/debian8/parallels.sh",
+        "scripts/debian8/vmware.sh",
+        "scripts/debian8/qemu.sh"
+      ],
+      "type": "shell",
+      "timeout": "120m",
+      "pause_before": "120s",
+      "start_retry_timeout": "15m",
+      "expect_disconnect": "true",
+      "only": [
+        "generic-debian8-x32-virtualbox"
+      ]
+    },
+    {
+      "scripts": [
         "scripts/debian9/apt.sh",
         "scripts/debian9/network.sh"
       ],
@@ -38,6 +72,57 @@
     }
   ],
   "builders": [
+    {
+      "type": "virtualbox-iso",
+      "name": "generic-debian8-x32-virtualbox",
+      "vm_name": "generic-debian8-x32-virtualbox",
+      "output_directory": "output/generic-debian8-x32-virtualbox",
+      "boot_wait": "10s",
+      "boot_command": [
+        "<esc><wait><esc><wait><esc><wait><esc><wait><esc><wait><esc><wait>",
+        "<esc><wait><esc><wait><esc><wait><esc><wait><esc><wait><esc><wait>",
+        "<esc><wait><esc><wait><esc><wait><esc><wait><esc><wait><esc><wait>",
+        "<esc><wait><esc><wait><esc><wait><esc><wait><esc><wait><esc><wait>",
+        "<esc><wait><esc><wait><esc><wait><esc><wait><esc><wait><esc><wait>",
+        "<esc><wait><esc><wait><esc><wait><esc><wait><esc><wait><esc><wait>",
+        "<esc><wait><esc><wait><esc><wait><esc><wait><esc><wait><esc><wait>",
+        "<esc><wait><esc><wait><esc><wait><esc><wait><esc><wait><esc><wait>",
+        "<esc><wait><esc><wait><esc><wait><esc><wait><esc><wait><esc><wait>",
+        "<esc><wait><esc><wait><esc><wait><esc><wait><esc><wait><esc><wait>",
+        "auto ",
+        "ipv6.disable_ipv6=1 net.ifnames=0 biosdevname=0 preseed/url=http://{{.HTTPIP}}:{{.HTTPPort}}/generic.debian8.vagrant.cfg ",
+        "<enter>"
+      ],
+      "disk_size": 131072,
+      "cpus": 2,
+      "memory": 2048,
+      "vboxmanage": [
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--vram",
+          "64"
+        ]
+      ],
+      "guest_os_type": "Debian_32",
+      "http_directory": "http",
+      "headless": true,
+      "vrdp_bind_address": "127.0.0.1",
+      "vrdp_port_min": 11000,
+      "vrdp_port_max": 12000,
+      "iso_url": "https://cdimage.debian.org/cdimage/archive/8.11.1/i386/iso-cd/debian-8.11.1-i386-netinst.iso",
+      "iso_checksum": "sha256:3741a984d170770f433ef694c823227298f7e8a2ff9c6486dc0b466ef9f8e710",
+      "ssh_username": "root",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_timeout": "3600s",
+      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
+      "guest_additions_url": "https://download.virtualbox.org/virtualbox/5.2.44/VBoxGuestAdditions_5.2.44.iso",
+      "guest_additions_sha256": "9883ee443a309f4ffa1d5dee2833f9e35ced598686c36d159f410e5edbac1ca4",
+      "guest_additions_path": "VBoxGuestAdditions.iso",
+      "guest_additions_mode": "upload",
+      "virtualbox_version_file": "VBoxVersion.txt"
+    },
     {
       "type": "virtualbox-iso",
       "name": "generic-debian9-x32-virtualbox",

--- a/packer-cache.json
+++ b/packer-cache.json
@@ -210,6 +210,21 @@
       "ssh_username": "root",
       "type": "vmware-iso"
     },
+     {
+      "name": "debian8-x32",
+      "output_directory": "output/debian8-x32",
+      "iso_url": "https://cdimage.debian.org/cdimage/archive/8.11.1/i386/iso-cd/debian-8.11.1-i386-netinst.iso",
+      "iso_checksum": "sha256:3741a984d170770f433ef694c823227298f7e8a2ff9c6486dc0b466ef9f8e710",
+      "boot_wait": "5s",
+      "disk_size": 1,
+      "headless": true,
+      "shutdown_command": "poweroff",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_timeout": "10s",
+      "ssh_username": "root",
+      "type": "vmware-iso"
+    },
     {
       "name": "debian9",
       "output_directory": "output/debian9",

--- a/scripts/debian8/network.sh
+++ b/scripts/debian8/network.sh
@@ -38,7 +38,7 @@ sysctl net.ipv6.conf.all.disable_ipv6=1
 printf "\nnet.ipv6.conf.all.disable_ipv6 = 1\n" >> /etc/sysctl.conf
 
 # Set the hostname, and then ensure it will resolve properly.
-if [[ "$PACKER_BUILD_NAME" =~ ^generic-debian8-(vmware|hyperv|libvirt|parallels|virtualbox)$ ]]; then
+if [[ "$PACKER_BUILD_NAME" =~ ^generic-debian8-(vmware|hyperv|libvirt|x32-libvirt|parallels|virtualbox|x32-virtualbox)$ ]]; then
   printf "debian8.localdomain\n" > /etc/hostname
   printf "\n127.0.0.1 debian8.localdomain\n\n" >> /etc/hosts
 else


### PR DESCRIPTION
Just like Debian 9, Debian 8 is still a very popular build target for compatibility with even older distributions. Sadly, the multiarch issues still apply here, so having a clean 32-bit box would be quite helpful.