### PR TITLE
Fix a few VirtualBox Guest Addition related issues

### DIFF
--- a/generic-virtualbox.json
+++ b/generic-virtualbox.json
@@ -3692,8 +3692,8 @@
       "ssh_port": 22,
       "ssh_timeout": "3600s",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
-      "guest_additions_url": "https://download.virtualbox.org/virtualbox/5.1.38/VBoxGuestAdditions_5.1.38.iso",
-      "guest_additions_sha256": "0e7ee2c78ebf7cd0d3a933d51148bef04a64f64fb27ccf70d59cddf9ca1e517a",
+      "guest_additions_url": "https://download.virtualbox.org/virtualbox/5.2.44/VBoxGuestAdditions_5.2.44.iso",
+      "guest_additions_sha256": "9883ee443a309f4ffa1d5dee2833f9e35ced598686c36d159f410e5edbac1ca4",
       "guest_additions_path": "VBoxGuestAdditions.iso",
       "guest_additions_mode": "upload",
       "virtualbox_version_file": "VBoxVersion.txt"

--- a/generic-virtualbox.json
+++ b/generic-virtualbox.json
@@ -2559,8 +2559,8 @@
       "ssh_port": 22,
       "ssh_timeout": "3600s",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
-      "guest_additions_url": "https://download.virtualbox.org/virtualbox/5.1.38/VBoxGuestAdditions_5.1.38.iso",
-      "guest_additions_sha256": "0e7ee2c78ebf7cd0d3a933d51148bef04a64f64fb27ccf70d59cddf9ca1e517a",
+      "guest_additions_url": "https://download.virtualbox.org/virtualbox/5.2.44/VBoxGuestAdditions_5.2.44.iso",
+      "guest_additions_sha256": "9883ee443a309f4ffa1d5dee2833f9e35ced598686c36d159f410e5edbac1ca4",
       "guest_additions_path": "VBoxGuestAdditions.iso",
       "guest_additions_mode": "upload",
       "virtualbox_version_file": "VBoxVersion.txt"

--- a/scripts/alpine35/virtualbox.sh
+++ b/scripts/alpine35/virtualbox.sh
@@ -106,6 +106,9 @@ mkdir -p /etc/depmod.d; error
 # if the service fails to start below.
 sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11
 
+# Test if the vboxsf module is present
+[ -s "/lib/modules/$(uname -r)/misc/vboxsf.ko" ]; error
+
 # Restore the real ldconfig binary.
 mv /root/ldconfig.bak /sbin/ldconfig; error
 

--- a/scripts/centos6/virtualbox.sh
+++ b/scripts/centos6/virtualbox.sh
@@ -52,6 +52,9 @@ getent passwd vboxadd >/dev/null || useradd --system --gid bin --home-dir /var/r
 sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11 || sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11; error
 ln -s /opt/VBoxGuestAdditions-$VBOXVERSION/lib/VBoxGuestAdditions /usr/lib/VBoxGuestAdditions; error
 
+# Test if the vboxsf module is present
+[ -s "/lib/modules/$(uname -r)/misc/vboxsf.ko" ]; error
+
 umount /mnt/virtualbox; error
 rm -rf /root/VBoxVersion.txt; error
 rm -rf /root/VBoxGuestAdditions.iso; error

--- a/scripts/centos7/virtualbox.sh
+++ b/scripts/centos7/virtualbox.sh
@@ -80,6 +80,9 @@ mount -o loop /root/VBoxGuestAdditions.iso /mnt/virtualbox; error
 sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11 || sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11; error
 ln -s /opt/VBoxGuestAdditions-$VBOXVERSION/lib/VBoxGuestAdditions /usr/lib/VBoxGuestAdditions; error
 
+# Test if the vboxsf module is present
+[ -s "/lib/modules/$(uname -r)/misc/vboxsf.ko" ]; error
+
 umount /mnt/virtualbox; error
 rm -rf /root/VBoxVersion.txt; error
 rm -rf /root/VBoxGuestAdditions.iso; error

--- a/scripts/centos8/virtualbox.sh
+++ b/scripts/centos8/virtualbox.sh
@@ -80,6 +80,9 @@ mount -o loop /root/VBoxGuestAdditions.iso /mnt/virtualbox; error
 sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11 || sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11; error
 ln -s /opt/VBoxGuestAdditions-$VBOXVERSION/lib/VBoxGuestAdditions /usr/lib/VBoxGuestAdditions; error
 
+# Test if the vboxsf module is present
+[ -s "/lib/modules/$(uname -r)/misc/vboxsf.ko" ]; error
+
 umount /mnt/virtualbox; error
 rm -rf /root/VBoxVersion.txt; error
 rm -rf /root/VBoxGuestAdditions.iso; error

--- a/scripts/debian10/virtualbox.sh
+++ b/scripts/debian10/virtualbox.sh
@@ -85,6 +85,9 @@ mount -o loop /root/VBoxGuestAdditions.iso /mnt/virtualbox; error
 sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11 || sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11; error
 ln -s /opt/VBoxGuestAdditions-$VBOXVERSION/lib/VBoxGuestAdditions /usr/lib/VBoxGuestAdditions; error
 
+# Test if the vboxsf module is present
+[ -s "/lib/modules/$(uname -r)/misc/vboxsf.ko" ]; error
+
 umount /mnt/virtualbox; error
 rm -rf /root/VBoxVersion.txt; error
 rm -rf /root/VBoxGuestAdditions.iso; error

--- a/scripts/debian10/virtualbox.sh
+++ b/scripts/debian10/virtualbox.sh
@@ -80,9 +80,9 @@ getent passwd vboxadd >/dev/null || useradd --system --gid bin --home-dir /var/r
 mkdir -p /mnt/virtualbox; error
 mount -o loop /root/VBoxGuestAdditions.iso /mnt/virtualbox; error
 
-# For some reason the vboxsf module fails the first time, but installs
-# successfully if we run the installer a second time.
-sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11 || sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11; error
+# Exit code 2 is not really an error here, it just means that the installer wasn't able to (re)load the module.
+# Since Linux has in-tree vboxguest and vboxvideo starting with kernel 4.16 we weren't able to reload it after installation.
+sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11 || [ $? -eq 2 ]; error
 ln -s /opt/VBoxGuestAdditions-$VBOXVERSION/lib/VBoxGuestAdditions /usr/lib/VBoxGuestAdditions; error
 
 # Test if the vboxsf module is present

--- a/scripts/debian8/virtualbox.sh
+++ b/scripts/debian8/virtualbox.sh
@@ -85,6 +85,9 @@ mount -o loop /root/VBoxGuestAdditions.iso /mnt/virtualbox; error
 sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11 || sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11; error
 ln -s /opt/VBoxGuestAdditions-$VBOXVERSION/lib/VBoxGuestAdditions /usr/lib/VBoxGuestAdditions; error
 
+# Test if the vboxsf module is present
+[ -s "/lib/modules/$(uname -r)/misc/vboxsf.ko" ]; error
+
 umount /mnt/virtualbox; error
 rm -rf /root/VBoxVersion.txt; error
 rm -rf /root/VBoxGuestAdditions.iso; error

--- a/scripts/debian9/virtualbox.sh
+++ b/scripts/debian9/virtualbox.sh
@@ -86,6 +86,9 @@ mount -o loop /root/VBoxGuestAdditions.iso /mnt/virtualbox; error
 sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11 || sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11; error
 ln -s /opt/VBoxGuestAdditions-$VBOXVERSION/lib/VBoxGuestAdditions /usr/lib/VBoxGuestAdditions; error
 
+# Test if the vboxsf module is present
+[ -s "/lib/modules/$(uname -r)/misc/vboxsf.ko" ]; error
+
 umount /mnt/virtualbox; error
 rm -rf /root/VBoxVersion.txt; error
 rm -rf /root/VBoxGuestAdditions.iso; error

--- a/scripts/devuan1/virtualbox.sh
+++ b/scripts/devuan1/virtualbox.sh
@@ -84,6 +84,9 @@ mount -o loop /root/VBoxGuestAdditions.iso /mnt/virtualbox; error
 sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11 || sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11; error
 ln -s /opt/VBoxGuestAdditions-$VBOXVERSION/lib/VBoxGuestAdditions /usr/lib/VBoxGuestAdditions; error
 
+# Test if the vboxsf module is present
+[ -s "/lib/modules/$(uname -r)/misc/vboxsf.ko" ]; error
+
 umount /mnt/virtualbox; error
 rm -rf /root/VBoxVersion.txt; error
 rm -rf /root/VBoxGuestAdditions.iso; error

--- a/scripts/devuan2/virtualbox.sh
+++ b/scripts/devuan2/virtualbox.sh
@@ -84,6 +84,9 @@ mount -o loop /root/VBoxGuestAdditions.iso /mnt/virtualbox; error
 sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11 || sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11; error
 ln -s /opt/VBoxGuestAdditions-$VBOXVERSION/lib/VBoxGuestAdditions /usr/lib/VBoxGuestAdditions; error
 
+# Test if the vboxsf module is present
+[ -s "/lib/modules/$(uname -r)/misc/vboxsf.ko" ]; error
+
 umount /mnt/virtualbox; error
 rm -rf /root/VBoxVersion.txt; error
 rm -rf /root/VBoxGuestAdditions.iso; error

--- a/scripts/devuan3/virtualbox.sh
+++ b/scripts/devuan3/virtualbox.sh
@@ -87,6 +87,9 @@ rmmod vboxguest
 sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11 || sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11; error
 ln -s /opt/VBoxGuestAdditions-$VBOXVERSION/lib/VBoxGuestAdditions /usr/lib/VBoxGuestAdditions; error
 
+# Test if the vboxsf module is present
+[ -s "/lib/modules/$(uname -r)/misc/vboxsf.ko" ]; error
+
 umount /mnt/virtualbox; error
 rm -rf /root/VBoxVersion.txt; error
 rm -rf /root/VBoxGuestAdditions.iso; error

--- a/scripts/fedora25/virtualbox.sh
+++ b/scripts/fedora25/virtualbox.sh
@@ -80,6 +80,9 @@ mount -o loop /root/VBoxGuestAdditions.iso /mnt/virtualbox; error
 sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11 || sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11; error
 ln -s /opt/VBoxGuestAdditions-$VBOXVERSION/lib/VBoxGuestAdditions /usr/lib/VBoxGuestAdditions; error
 
+# Test if the vboxsf module is present
+[ -s "/lib/modules/$(uname -r)/misc/vboxsf.ko" ]; error
+
 umount /mnt/virtualbox; error
 rm -rf /root/VBoxVersion.txt; error
 rm -rf /root/VBoxGuestAdditions.iso; error

--- a/scripts/fedora26/virtualbox.sh
+++ b/scripts/fedora26/virtualbox.sh
@@ -80,6 +80,9 @@ mount -o loop /root/VBoxGuestAdditions.iso /mnt/virtualbox; error
 sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11 || sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11; error
 ln -s /opt/VBoxGuestAdditions-$VBOXVERSION/lib/VBoxGuestAdditions /usr/lib/VBoxGuestAdditions; error
 
+# Test if the vboxsf module is present
+[ -s "/lib/modules/$(uname -r)/misc/vboxsf.ko" ]; error
+
 umount /mnt/virtualbox; error
 rm -rf /root/VBoxVersion.txt; error
 rm -rf /root/VBoxGuestAdditions.iso; error

--- a/scripts/fedora27/virtualbox.sh
+++ b/scripts/fedora27/virtualbox.sh
@@ -74,9 +74,9 @@ getent passwd vboxadd >/dev/null || useradd --system --gid bin --home-dir /var/r
 mkdir -p /mnt/virtualbox; error
 mount -o loop /root/VBoxGuestAdditions.iso /mnt/virtualbox; error
 
-# For some reason the vboxsf module fails the first time, but installs
-# successfully if we run the installer a second time.
-sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11 || sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11; error
+# Exit code 2 is not really an error here, it just means that the installer wasn't able to reload the module.
+# Since Linux has in-tree vboxguest and vboxvideo starting with kernel 4.16 we weren't able to reload it after installation.
+sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11 || [ $? -eq 2 ]; error
 ln -s /opt/VBoxGuestAdditions-$VBOXVERSION/lib/VBoxGuestAdditions /usr/lib/VBoxGuestAdditions; error
 
 # Test if the vboxsf module is present

--- a/scripts/fedora27/virtualbox.sh
+++ b/scripts/fedora27/virtualbox.sh
@@ -79,6 +79,9 @@ mount -o loop /root/VBoxGuestAdditions.iso /mnt/virtualbox; error
 sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11 || sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11; error
 ln -s /opt/VBoxGuestAdditions-$VBOXVERSION/lib/VBoxGuestAdditions /usr/lib/VBoxGuestAdditions; error
 
+# Test if the vboxsf module is present
+[ -s "/lib/modules/$(uname -r)/misc/vboxsf.ko" ]; error
+
 umount /mnt/virtualbox; error
 rm -rf /root/VBoxVersion.txt; error
 rm -rf /root/VBoxGuestAdditions.iso; error

--- a/scripts/fedora28/virtualbox.sh
+++ b/scripts/fedora28/virtualbox.sh
@@ -74,6 +74,9 @@ retry dnf install --assumeyes virtualbox-guest-additions; error
 # sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11 || sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11; error
 # ln -s /opt/VBoxGuestAdditions-$VBOXVERSION/lib/VBoxGuestAdditions /usr/lib/VBoxGuestAdditions; error
 #
+# # Test if the vboxsf module is present
+# [ -s "/lib/modules/$(uname -r)/misc/vboxsf.ko" ]; error
+#
 # umount /mnt/virtualbox; error
 rm -rf /root/VBoxVersion.txt; error
 rm -rf /root/VBoxGuestAdditions.iso; error

--- a/scripts/fedora29/virtualbox.sh
+++ b/scripts/fedora29/virtualbox.sh
@@ -79,6 +79,9 @@ retry dnf install --assumeyes virtualbox-guest-additions; error
 # sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11 || sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11; error
 # ln -s /opt/VBoxGuestAdditions-$VBOXVERSION/lib/VBoxGuestAdditions /usr/lib/VBoxGuestAdditions; error
 #
+# # Test if the vboxsf module is present
+# [ -s "/lib/modules/$(uname -r)/misc/vboxsf.ko" ]; error
+#
 # umount /mnt/virtualbox; error
 rm -rf /root/VBoxVersion.txt; error
 rm -rf /root/VBoxGuestAdditions.iso; error

--- a/scripts/fedora30/virtualbox.sh
+++ b/scripts/fedora30/virtualbox.sh
@@ -79,6 +79,9 @@ retry dnf install --assumeyes virtualbox-guest-additions; error
 # sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11 || sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11; error
 # ln -s /opt/VBoxGuestAdditions-$VBOXVERSION/lib/VBoxGuestAdditions /usr/lib/VBoxGuestAdditions; error
 #
+# # Test if the vboxsf module is present
+# [ -s "/lib/modules/$(uname -r)/misc/vboxsf.ko" ]; error
+#
 # umount /mnt/virtualbox; error
 rm -rf /root/VBoxVersion.txt; error
 rm -rf /root/VBoxGuestAdditions.iso; error

--- a/scripts/fedora31/virtualbox.sh
+++ b/scripts/fedora31/virtualbox.sh
@@ -74,6 +74,9 @@ retry dnf install --assumeyes virtualbox-guest-additions; error
 # sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11 || sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11; error
 # ln -s /opt/VBoxGuestAdditions-$VBOXVERSION/lib/VBoxGuestAdditions /usr/lib/VBoxGuestAdditions; error
 #
+# # Test if the vboxsf module is present
+# [ -s "/lib/modules/$(uname -r)/misc/vboxsf.ko" ]; error
+#
 # umount /mnt/virtualbox; error
 rm -rf /root/VBoxVersion.txt; error
 rm -rf /root/VBoxGuestAdditions.iso; error

--- a/scripts/fedora32/virtualbox.sh
+++ b/scripts/fedora32/virtualbox.sh
@@ -74,6 +74,9 @@ retry dnf install --assumeyes virtualbox-guest-additions; error
 # sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11 || sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11; error
 # ln -s /opt/VBoxGuestAdditions-$VBOXVERSION/lib/VBoxGuestAdditions /usr/lib/VBoxGuestAdditions; error
 #
+# # Test if the vboxsf module is present
+# [ -s "/lib/modules/$(uname -r)/misc/vboxsf.ko" ]; error
+#
 # umount /mnt/virtualbox; error
 rm -rf /root/VBoxVersion.txt; error
 rm -rf /root/VBoxGuestAdditions.iso; error

--- a/scripts/fedora33/virtualbox.sh
+++ b/scripts/fedora33/virtualbox.sh
@@ -74,6 +74,9 @@ retry dnf install --assumeyes virtualbox-guest-additions; error
 # sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11 || sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11; error
 # ln -s /opt/VBoxGuestAdditions-$VBOXVERSION/lib/VBoxGuestAdditions /usr/lib/VBoxGuestAdditions; error
 #
+# # Test if the vboxsf module is present
+# [ -s "/lib/modules/$(uname -r)/misc/vboxsf.ko" ]; error
+#
 # umount /mnt/virtualbox; error
 rm -rf /root/VBoxVersion.txt; error
 rm -rf /root/VBoxGuestAdditions.iso; error

--- a/scripts/oracle7/virtualbox.sh
+++ b/scripts/oracle7/virtualbox.sh
@@ -58,6 +58,9 @@ mount -o loop /root/VBoxGuestAdditions.iso /mnt/virtualbox; error
 sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11 || sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11; error
 ln -s /opt/VBoxGuestAdditions-$VBOXVERSION/lib/VBoxGuestAdditions /usr/lib/VBoxGuestAdditions; error
 
+# Test if the vboxsf module is present
+[ -s "/lib/modules/$(uname -r)/misc/vboxsf.ko" ]; error
+
 umount /mnt/virtualbox; error
 rm -rf /root/VBoxVersion.txt
 rm -rf /root/VBoxGuestAdditions.iso

--- a/scripts/oracle8/virtualbox.sh
+++ b/scripts/oracle8/virtualbox.sh
@@ -84,6 +84,9 @@ mount -o loop /root/VBoxGuestAdditions.iso /mnt/virtualbox; error
 sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11 || sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11; error
 ln -s /opt/VBoxGuestAdditions-$VBOXVERSION/lib/VBoxGuestAdditions /usr/lib/VBoxGuestAdditions; error
 
+# Test if the vboxsf module is present
+[ -s "/lib/modules/$(uname -r)/misc/vboxsf.ko" ]; error
+
 umount /mnt/virtualbox; error
 rm -rf /root/VBoxVersion.txt
 rm -rf /root/VBoxGuestAdditions.iso

--- a/scripts/rhel6/virtualbox.sh
+++ b/scripts/rhel6/virtualbox.sh
@@ -59,6 +59,9 @@ getent passwd vboxadd >/dev/null || useradd --system --gid bin --home-dir /var/r
 sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11 || sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11; error
 ln -s /opt/VBoxGuestAdditions-$VBOXVERSION/lib/VBoxGuestAdditions /usr/lib/VBoxGuestAdditions; error
 
+# Test if the vboxsf module is present
+[ -s "/lib/modules/$(uname -r)/misc/vboxsf.ko" ]; error
+
 umount /mnt/virtualbox; error
 rm -rf /root/VBoxVersion.txt; error
 rm -rf /root/VBoxGuestAdditions.iso; error

--- a/scripts/rhel7/virtualbox.sh
+++ b/scripts/rhel7/virtualbox.sh
@@ -61,6 +61,9 @@ mount -o loop /root/VBoxGuestAdditions.iso /mnt/virtualbox; error
 sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11 || sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11; error
 ln -s /opt/VBoxGuestAdditions-$VBOXVERSION/lib/VBoxGuestAdditions /usr/lib/VBoxGuestAdditions; error
 
+# Test if the vboxsf module is present
+[ -s "/lib/modules/$(uname -r)/misc/vboxsf.ko" ]; error
+
 umount /mnt/virtualbox; error
 rm -rf /root/VBoxVersion.txt; error
 rm -rf /root/VBoxGuestAdditions.iso; error

--- a/scripts/rhel8/virtualbox.sh
+++ b/scripts/rhel8/virtualbox.sh
@@ -62,6 +62,9 @@ mount -o loop /root/VBoxGuestAdditions.iso /mnt/virtualbox; error
 sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11 || sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11; error
 ln -s /opt/VBoxGuestAdditions-$VBOXVERSION/lib/VBoxGuestAdditions /usr/lib/VBoxGuestAdditions; error
 
+# Test if the vboxsf module is present
+[ -s "/lib/modules/$(uname -r)/misc/vboxsf.ko" ]; error
+
 umount /mnt/virtualbox; error
 rm -rf /root/VBoxVersion.txt; error
 rm -rf /root/VBoxGuestAdditions.iso; error

--- a/scripts/ubuntu1604/virtualbox.sh
+++ b/scripts/ubuntu1604/virtualbox.sh
@@ -66,6 +66,9 @@ export VBOXVERSION=`cat /root/VBoxVersion.txt`
 # sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11 || sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11; error
 # ln -s /opt/VBoxGuestAdditions-$VBOXVERSION/lib/VBoxGuestAdditions /usr/lib/VBoxGuestAdditions; error
 #
+# # Test if the vboxsf module is present
+# [ -s "/lib/modules/$(uname -r)/misc/vboxsf.ko" ]; error
+#
 # umount /mnt/virtualbox; error
 rm -rf /root/VBoxVersion.txt; error
 rm -rf /root/VBoxGuestAdditions.iso; error

--- a/scripts/ubuntu1610/virtualbox.sh
+++ b/scripts/ubuntu1610/virtualbox.sh
@@ -66,6 +66,9 @@ export VBOXVERSION=`cat /root/VBoxVersion.txt`
 # sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11 || sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11; error
 # ln -s /opt/VBoxGuestAdditions-$VBOXVERSION/lib/VBoxGuestAdditions /usr/lib/VBoxGuestAdditions; error
 #
+# # Test if the vboxsf module is present
+# [ -s "/lib/modules/$(uname -r)/misc/vboxsf.ko" ]; error
+#
 # umount /mnt/virtualbox
 rm -rf /root/VBoxVersion.txt
 rm -rf /root/VBoxGuestAdditions.iso

--- a/scripts/ubuntu1704/virtualbox.sh
+++ b/scripts/ubuntu1704/virtualbox.sh
@@ -66,6 +66,9 @@ export VBOXVERSION=`cat /root/VBoxVersion.txt`
 # sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11 || sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11; error
 # ln -s /opt/VBoxGuestAdditions-$VBOXVERSION/lib/VBoxGuestAdditions /usr/lib/VBoxGuestAdditions; error
 #
+# # Test if the vboxsf module is present
+# [ -s "/lib/modules/$(uname -r)/misc/vboxsf.ko" ]; error
+#
 # umount /mnt/virtualbox; error
 rm -rf /root/VBoxVersion.txt; error
 rm -rf /root/VBoxGuestAdditions.iso; error

--- a/scripts/ubuntu1710/virtualbox.sh
+++ b/scripts/ubuntu1710/virtualbox.sh
@@ -66,6 +66,9 @@ export VBOXVERSION=`cat /root/VBoxVersion.txt`
 # sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11 || sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11; error
 # ln -s /opt/VBoxGuestAdditions-$VBOXVERSION/lib/VBoxGuestAdditions /usr/lib/VBoxGuestAdditions; error
 #
+# # Test if the vboxsf module is present
+# [ -s "/lib/modules/$(uname -r)/misc/vboxsf.ko" ]; error
+#
 # umount /mnt/virtualbox; error
 rm -rf /root/VBoxVersion.txt; error
 rm -rf /root/VBoxGuestAdditions.iso; error

--- a/scripts/ubuntu1804/virtualbox.sh
+++ b/scripts/ubuntu1804/virtualbox.sh
@@ -66,6 +66,9 @@ export VBOXVERSION=`cat /root/VBoxVersion.txt`
 # sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11 || sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11; error
 # ln -s /opt/VBoxGuestAdditions-$VBOXVERSION/lib/VBoxGuestAdditions /usr/lib/VBoxGuestAdditions; error
 #
+# # Test if the vboxsf module is present
+# [ -s "/lib/modules/$(uname -r)/misc/vboxsf.ko" ]; error
+#
 # umount /mnt/virtualbox; error
 rm -rf /root/VBoxVersion.txt; error
 rm -rf /root/VBoxGuestAdditions.iso; error

--- a/scripts/ubuntu1810/virtualbox.sh
+++ b/scripts/ubuntu1810/virtualbox.sh
@@ -66,6 +66,9 @@ export VBOXVERSION=`cat /root/VBoxVersion.txt`
 # sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11 || sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11; error
 # ln -s /opt/VBoxGuestAdditions-$VBOXVERSION/lib/VBoxGuestAdditions /usr/lib/VBoxGuestAdditions; error
 #
+# # Test if the vboxsf module is present
+# [ -s "/lib/modules/$(uname -r)/misc/vboxsf.ko" ]; error
+#
 # umount /mnt/virtualbox; error
 rm -rf /root/VBoxVersion.txt; error
 rm -rf /root/VBoxGuestAdditions.iso; error

--- a/scripts/ubuntu1904/virtualbox.sh
+++ b/scripts/ubuntu1904/virtualbox.sh
@@ -71,6 +71,9 @@ export VBOXVERSION=`cat /root/VBoxVersion.txt`
 # sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11 || sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11; error
 # ln -s /opt/VBoxGuestAdditions-$VBOXVERSION/lib/VBoxGuestAdditions /usr/lib/VBoxGuestAdditions; error
 #
+# # Test if the vboxsf module is present
+# [ -s "/lib/modules/$(uname -r)/misc/vboxsf.ko" ]; error
+#
 # umount /mnt/virtualbox; error
 rm -rf /root/VBoxVersion.txt; error
 rm -rf /root/VBoxGuestAdditions.iso; error

--- a/scripts/ubuntu1910/virtualbox.sh
+++ b/scripts/ubuntu1910/virtualbox.sh
@@ -71,6 +71,9 @@ export VBOXVERSION=`cat /root/VBoxVersion.txt`
 # sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11 || sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11; error
 # ln -s /opt/VBoxGuestAdditions-$VBOXVERSION/lib/VBoxGuestAdditions /usr/lib/VBoxGuestAdditions; error
 #
+# # Test if the vboxsf module is present
+# [ -s "/lib/modules/$(uname -r)/misc/vboxsf.ko" ]; error
+#
 # umount /mnt/virtualbox; error
 rm -rf /root/VBoxVersion.txt; error
 rm -rf /root/VBoxGuestAdditions.iso; error

--- a/scripts/ubuntu2004/virtualbox.sh
+++ b/scripts/ubuntu2004/virtualbox.sh
@@ -71,6 +71,9 @@ export VBOXVERSION=`cat /root/VBoxVersion.txt`
 # sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11 || sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11; error
 # ln -s /opt/VBoxGuestAdditions-$VBOXVERSION/lib/VBoxGuestAdditions /usr/lib/VBoxGuestAdditions; error
 #
+# # Test if the vboxsf module is present
+# [ -s "/lib/modules/$(uname -r)/misc/vboxsf.ko" ]; error
+#
 # umount /mnt/virtualbox; error
 rm -rf /root/VBoxVersion.txt; error
 rm -rf /root/VBoxGuestAdditions.iso; error

--- a/scripts/ubuntu2010/virtualbox.sh
+++ b/scripts/ubuntu2010/virtualbox.sh
@@ -71,6 +71,9 @@ export VBOXVERSION=`cat /root/VBoxVersion.txt`
 # sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11 || sh /mnt/virtualbox/VBoxLinuxAdditions.run --nox11; error
 # ln -s /opt/VBoxGuestAdditions-$VBOXVERSION/lib/VBoxGuestAdditions /usr/lib/VBoxGuestAdditions; error
 #
+# # Test if the vboxsf module is present
+# [ -s "/lib/modules/$(uname -r)/misc/vboxsf.ko" ]; error
+#
 # umount /mnt/virtualbox; error
 rm -rf /root/VBoxVersion.txt; error
 rm -rf /root/VBoxGuestAdditions.iso; error


### PR DESCRIPTION
All boxes that rely on the VirtualBox Guest Additions ISO will now check for the presence of the `vboxsf` kernel module and abort the build otherwise.

Debian 10 and Fedora 27 (which previously had a broken/missing `vboxsf` module) also got fixed and now use the current default VirtualBox version.

Fixes: #196 