### PR TITLE
Some fixes for Lineage

### DIFF
--- a/lineage-hyperv.json
+++ b/lineage-hyperv.json
@@ -101,7 +101,7 @@
                 "fb=false auto-install/enable=true debconf/priority=critical debconf/frontend=noninteractive ",
                 "ipv6.disable_ipv6=1 net.ifnames=0 biosdevname=0 preseed/url=http://{{.HTTPIP}}:{{.HTTPPort}}/lineage.ubuntu1604.vagrant.cfg --- <wait><enter>"
             ],
-            "disk_size": 98304,
+            "disk_size": 256000,
             "memory": 2048,
             "cpus": 4,
             "http_directory": "http",
@@ -147,7 +147,7 @@
                 "fb=false auto-install/enable=true debconf/priority=critical debconf/frontend=noninteractive ",
                 "ipv6.disable_ipv6=1 net.ifnames=0 biosdevname=0 preseed/url=http://{{.HTTPIP}}:{{.HTTPPort}}/lineage.ubuntu1604.vagrant.cfg --- <wait><enter>"
             ],
-            "disk_size": 98304,
+            "disk_size": 256000,
             "memory": 2048,
             "cpus": 4,
             "http_directory": "http",

--- a/lineage-hyperv.json
+++ b/lineage-hyperv.json
@@ -13,9 +13,7 @@
             "start_retry_timeout": "45m",
             "expect_disconnect": "true",
             "only": [
-                "lineage-hyperv",
-                "lineage-nash-hyperv"
-
+                "lineage-hyperv"
             ]
         },
         {
@@ -38,9 +36,7 @@
             "start_retry_timeout": "45m",
             "expect_disconnect": "true",
             "only": [
-                "lineage-hyperv",
-                "lineage-nash-hyperv"
-
+                "lineage-hyperv"
             ]
         },
         {
@@ -52,9 +48,7 @@
             "start_retry_timeout": "45m",
             "expect_disconnect": "true",
             "only": [
-                "lineage-hyperv",
-                "lineage-nash-hyperv"
-
+                "lineage-hyperv"
             ]
         },
         {
@@ -121,54 +115,8 @@
             "enable_dynamic_memory": false,
             "guest_additions_mode": "disable",
             "enable_virtualization_extensions": false
-        },
-        {
-            "type": "hyperv-iso",
-            "name": "lineage-nash-hyperv",
-            "vm_name": "lineage-nash-hyperv",
-            "temp_path": "output/",
-            "output_directory": "output/lineage-nash-hyperv",
-            "boot_wait": "20s",
-            "boot_keygroup_interval": "1s",
-            "boot_command": [
-                "<enter><wait>",
-                "<f6><esc>",
-                "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-                "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-                "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-                "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-                "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-                "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-                "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-                "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-                "<bs><bs><bs>",
-                "/install/vmlinuz ",
-                "initrd=/install/initrd.gz ",
-                "fb=false auto-install/enable=true debconf/priority=critical debconf/frontend=noninteractive ",
-                "ipv6.disable_ipv6=1 net.ifnames=0 biosdevname=0 preseed/url=http://{{.HTTPIP}}:{{.HTTPPort}}/lineage.ubuntu1604.vagrant.cfg --- <wait><enter>"
-            ],
-            "disk_size": 256000,
-            "memory": 2048,
-            "cpus": 4,
-            "http_directory": "http",
-            "iso_url": "https://mirrors.kernel.org/ubuntu-releases/16.04.7/ubuntu-16.04.7-server-amd64.iso",
-            "iso_checksum": "sha256:b23488689e16cad7a269eb2d3a3bf725d3457ee6b0868e00c8762d3816e25848",
-            "ssh_username": "root",
-            "ssh_password": "vagrant",
-            "ssh_port": 22,
-            "ssh_timeout": "7200s",
-            "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
-            "generation": 1,
-            "headless": true,
-            "communicator": "ssh",
-            "skip_compaction": false,
-            "enable_secure_boot": false,
-            "enable_mac_spoofing": true,
-            "enable_dynamic_memory": false,
-            "guest_additions_mode": "disable",
-            "enable_virtualization_extensions": false
         }
-    ],
+   ],
     "post-processors": [
         [
             {

--- a/lineage-hyperv.json
+++ b/lineage-hyperv.json
@@ -44,17 +44,6 @@
             ]
         },
         {
-            "type": "file",
-            "direction": "upload",
-            "source": "res/blobs/system-blobs.tar.gz",
-            "destination": "/home/vagrant/system-blobs.tar.gz",
-            "only": [
-                "lineage-hyperv",
-                "lineage-nash-hyperv"
-
-            ]
-        },
-        {
             "scripts": [
                 "scripts/ubuntu1604/lineage.sh"
             ],

--- a/lineage-libvirt.json
+++ b/lineage-libvirt.json
@@ -44,17 +44,6 @@
             ]
         },
         {
-            "type": "file",
-            "direction": "upload",
-            "source": "res/blobs/system-blobs.tar.gz",
-            "destination": "/home/vagrant/system-blobs.tar.gz",
-            "only": [
-                "lineage-libvirt",
-                "lineage-nash-libvirt"
-
-            ]
-        },
-        {
             "scripts": [
                 "scripts/ubuntu1604/lineage.sh"
             ],

--- a/lineage-libvirt.json
+++ b/lineage-libvirt.json
@@ -105,7 +105,7 @@
                 "<enter>"
             ],
             "format": "qcow2",
-            "disk_size": "196608",
+            "disk_size": "256000",
             "disk_discard": "unmap",
             "disk_detect_zeroes": "unmap",
             "disk_cache": "unsafe",
@@ -154,7 +154,7 @@
                 "<enter>"
             ],
             "format": "qcow2",
-            "disk_size": "196608",
+            "disk_size": "256000",
             "disk_discard": "unmap",
             "disk_detect_zeroes": "unmap",
             "disk_cache": "unsafe",

--- a/lineage-libvirt.json
+++ b/lineage-libvirt.json
@@ -13,9 +13,7 @@
             "start_retry_timeout": "15m",
             "expect_disconnect": "true",
             "only": [
-                "lineage-libvirt",
-                "lineage-nash-libvirt"
-
+                "lineage-libvirt"
             ]
         },
         {
@@ -38,9 +36,7 @@
             "start_retry_timeout": "15m",
             "expect_disconnect": "true",
             "only": [
-                "lineage-libvirt",
-                "lineage-nash-libvirt"
-
+                "lineage-libvirt"
             ]
         },
         {
@@ -52,9 +48,7 @@
             "start_retry_timeout": "15m",
             "expect_disconnect": "true",
             "only": [
-                "lineage-libvirt",
-                "lineage-nash-libvirt"
-
+                "lineage-libvirt"
             ]
         },
         {
@@ -81,55 +75,6 @@
             "name": "lineage-libvirt",
             "vm_name": "lineage-libvirt",
             "output_directory": "output/lineage-libvirt",
-            "accelerator": "kvm",
-            "qemu_binary": "/usr/libexec/qemu-kvm",
-            "boot_wait": "20s",
-            "boot_keygroup_interval": "1s",
-            "boot_command": [
-                "<enter><wait>",
-                "<f6><esc>",
-                "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-                "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-                "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-                "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-                "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-                "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-                "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-                "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-                "<bs><bs><bs>",
-                "/install/vmlinuz ",
-                "initrd=/install/initrd.gz ",
-                "auto-install/enable=true ",
-                "debconf/priority=critical ",
-                "ipv6.disable_ipv6=1 net.ifnames=0 biosdevname=0 preseed/url=http://{{.HTTPIP}}:{{.HTTPPort}}/lineage.ubuntu1604.vagrant.cfg<wait> ",
-                "<enter>"
-            ],
-            "format": "qcow2",
-            "disk_size": "256000",
-            "disk_discard": "unmap",
-            "disk_detect_zeroes": "unmap",
-            "disk_cache": "unsafe",
-            "disk_image": false,
-            "disk_compression": true,
-            "disk_interface": "virtio-scsi",
-            "net_device": "virtio-net",
-            "cpus": 4,
-            "memory": 2048,
-            "http_directory": "http",
-            "headless": true,
-            "iso_url": "https://mirrors.kernel.org/ubuntu-releases/16.04.7/ubuntu-16.04.7-server-amd64.iso",
-            "iso_checksum": "sha256:b23488689e16cad7a269eb2d3a3bf725d3457ee6b0868e00c8762d3816e25848",
-            "ssh_username": "root",
-            "ssh_password": "vagrant",
-            "ssh_port": 22,
-            "ssh_timeout": "3600s",
-            "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now"
-        },
-        {
-            "type": "qemu",
-            "name": "lineage-nash-libvirt",
-            "vm_name": "lineage-nash-libvirt",
-            "output_directory": "output/lineage-nash-libvirt",
             "accelerator": "kvm",
             "qemu_binary": "/usr/libexec/qemu-kvm",
             "boot_wait": "20s",

--- a/lineage-virtualbox.json
+++ b/lineage-virtualbox.json
@@ -44,17 +44,6 @@
             ]
         },
         {
-            "type": "file",
-            "direction": "upload",
-            "source": "res/blobs/system-blobs.tar.gz",
-            "destination": "/home/vagrant/system-blobs.tar.gz",
-            "only": [
-                "lineage-virtualbox",
-                "lineage-nash-virtualbox"
-
-            ]
-        },
-        {
             "scripts": [
                 "scripts/ubuntu1604/lineage.sh"
             ],

--- a/lineage-virtualbox.json
+++ b/lineage-virtualbox.json
@@ -102,7 +102,7 @@
                 "ipv6.disable_ipv6=1 net.ifnames=0 biosdevname=0 preseed/url=http://{{.HTTPIP}}:{{.HTTPPort}}/lineage.ubuntu1604.vagrant.cfg<wait> ",
                 "<enter>"
             ],
-            "disk_size": 196608,
+            "disk_size": 256000,
             "cpus": 4,
             "memory": 2048,
             "vboxmanage": [
@@ -158,7 +158,7 @@
                 "ipv6.disable_ipv6=1 net.ifnames=0 biosdevname=0 preseed/url=http://{{.HTTPIP}}:{{.HTTPPort}}/lineage.ubuntu1604.vagrant.cfg<wait> ",
                 "<enter>"
             ],
-            "disk_size": 196608,
+            "disk_size": 256000,
             "cpus": 4,
             "memory": 2048,
             "vboxmanage": [

--- a/lineage-virtualbox.json
+++ b/lineage-virtualbox.json
@@ -13,9 +13,7 @@
             "start_retry_timeout": "15m",
             "expect_disconnect": "true",
             "only": [
-                "lineage-virtualbox",
-                "lineage-nash-virtualbox"
-
+                "lineage-virtualbox"
             ]
         },
         {
@@ -38,9 +36,7 @@
             "start_retry_timeout": "15m",
             "expect_disconnect": "true",
             "only": [
-                "lineage-virtualbox",
-                "lineage-nash-virtualbox"
-
+                "lineage-virtualbox"
             ]
         },
         {
@@ -52,9 +48,7 @@
             "start_retry_timeout": "15m",
             "expect_disconnect": "true",
             "only": [
-                "lineage-virtualbox",
-                "lineage-nash-virtualbox"
-
+                "lineage-virtualbox"
             ]
         },
         {
@@ -81,62 +75,6 @@
             "name": "lineage-virtualbox",
             "vm_name": "lineage-virtualbox",
             "output_directory": "output/lineage-virtualbox",
-            "boot_wait": "20s",
-            "boot_keygroup_interval": "1s",
-            "boot_command": [
-                "<enter><wait>",
-                "<f6><esc>",
-                "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-                "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-                "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-                "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-                "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-                "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-                "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-                "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-                "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-                "/install/vmlinuz ",
-                "initrd=/install/initrd.gz ",
-                "auto-install/enable=true ",
-                "debconf/priority=critical ",
-                "ipv6.disable_ipv6=1 net.ifnames=0 biosdevname=0 preseed/url=http://{{.HTTPIP}}:{{.HTTPPort}}/lineage.ubuntu1604.vagrant.cfg<wait> ",
-                "<enter>"
-            ],
-            "disk_size": 256000,
-            "cpus": 4,
-            "memory": 2048,
-            "vboxmanage": [
-                [
-                    "modifyvm",
-                    "{{.Name}}",
-                    "--vram",
-                    "64"
-                ]
-            ],
-            "guest_os_type": "Ubuntu_64",
-            "http_directory": "http",
-            "headless": true,
-            "vrdp_bind_address": "127.0.0.1",
-            "vrdp_port_min": 11000,
-            "vrdp_port_max": 12000,
-            "iso_url": "https://mirrors.kernel.org/ubuntu-releases/16.04.7/ubuntu-16.04.7-server-amd64.iso",
-            "iso_checksum": "sha256:b23488689e16cad7a269eb2d3a3bf725d3457ee6b0868e00c8762d3816e25848",
-            "ssh_username": "root",
-            "ssh_password": "vagrant",
-            "ssh_port": 22,
-            "ssh_timeout": "3600s",
-            "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
-            "guest_additions_url": "https://download.virtualbox.org/virtualbox/5.2.44/VBoxGuestAdditions_5.2.44.iso",
-            "guest_additions_sha256": "9883ee443a309f4ffa1d5dee2833f9e35ced598686c36d159f410e5edbac1ca4",
-            "guest_additions_path": "VBoxGuestAdditions.iso",
-            "guest_additions_mode": "upload",
-            "virtualbox_version_file": "VBoxVersion.txt"
-        },
-        {
-            "type": "virtualbox-iso",
-            "name": "lineage-nash-virtualbox",
-            "vm_name": "lineage-nash-virtualbox",
-            "output_directory": "output/lineage-nash-virtualbox",
             "boot_wait": "20s",
             "boot_keygroup_interval": "1s",
             "boot_command": [

--- a/lineage-vmware.json
+++ b/lineage-vmware.json
@@ -13,9 +13,7 @@
             "start_retry_timeout": "15m",
             "expect_disconnect": "true",
             "only": [
-                "lineage-vmware",
-                "lineage-nash-vmware"
-
+                "lineage-vmware"
             ]
         },
         {
@@ -38,9 +36,7 @@
             "start_retry_timeout": "15m",
             "expect_disconnect": "true",
             "only": [
-                "lineage-vmware",
-                "lineage-nash-vmware"
-
+                "lineage-vmware"
             ]
         },
         {
@@ -52,9 +48,7 @@
             "start_retry_timeout": "15m",
             "expect_disconnect": "true",
             "only": [
-                "lineage-vmware",
-                "lineage-nash-vmware"
-
+                "lineage-vmware"
             ]
         },
         {
@@ -82,62 +76,6 @@
             "vm_name": "lineage-vmware",
             "vmdk_name": "lineage-vmware",
             "output_directory": "output/lineage-vmware",
-            "boot_wait": "20s",
-            "boot_keygroup_interval": "1s",
-            "boot_command": [
-                "<enter><wait>",
-                "<f6><esc>",
-                "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-                "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-                "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-                "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-                "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-                "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-                "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-                "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-                "<bs><bs><bs>",
-                "/install/vmlinuz ",
-                "initrd=/install/initrd.gz ",
-                "auto-install/enable=true ",
-                "debconf/priority=critical ",
-                "ipv6.disable_ipv6=1 net.ifnames=0 biosdevname=0 preseed/url=http://{{.HTTPIP}}:{{.HTTPPort}}/lineage.ubuntu1604.vagrant.cfg<wait> ",
-                "<enter>"
-            ],
-            "disk_size": 256000,
-            "disk_type_id": "0",
-            "cpus": 4,
-            "memory": 2048,
-            "version": "12",
-            "vmx_data_post": {
-              "virtualHW.version": "12",
-              "cleanShutdown": "TRUE",
-              "softPowerOff": "FALSE",
-              "ethernet0.virtualDev": "e1000",
-              "ethernet0.startConnected": "TRUE",
-              "ethernet0.wakeonpcktrcv": "false"
-            },
-            "guest_os_type": "ubuntu-64",
-            "skip_compaction": false,
-            "http_directory": "http",
-            "headless": true,
-            "vnc_disable_password": true,
-            "vnc_bind_address": "127.0.0.1",
-            "vmx_remove_ethernet_interfaces": true,
-            "iso_url": "https://mirrors.kernel.org/ubuntu-releases/16.04.7/ubuntu-16.04.7-server-amd64.iso",
-            "iso_checksum": "sha256:b23488689e16cad7a269eb2d3a3bf725d3457ee6b0868e00c8762d3816e25848",
-            "ssh_username": "root",
-            "ssh_password": "vagrant",
-            "ssh_port": 22,
-            "ssh_timeout": "3600s",
-            "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
-            "tools_upload_flavor": "linux"
-        },
-        {
-            "type": "vmware-iso",
-            "name": "lineage-nash-vmware",
-            "vm_name": "lineage-nash-vmware",
-            "vmdk_name": "lineage-nash-vmware",
-            "output_directory": "output/lineage-nash-vmware",
             "boot_wait": "20s",
             "boot_keygroup_interval": "1s",
             "boot_command": [

--- a/lineage-vmware.json
+++ b/lineage-vmware.json
@@ -103,7 +103,7 @@
                 "ipv6.disable_ipv6=1 net.ifnames=0 biosdevname=0 preseed/url=http://{{.HTTPIP}}:{{.HTTPPort}}/lineage.ubuntu1604.vagrant.cfg<wait> ",
                 "<enter>"
             ],
-            "disk_size": 196608,
+            "disk_size": 256000,
             "disk_type_id": "0",
             "cpus": 4,
             "memory": 2048,
@@ -159,7 +159,7 @@
                 "ipv6.disable_ipv6=1 net.ifnames=0 biosdevname=0 preseed/url=http://{{.HTTPIP}}:{{.HTTPPort}}/lineage.ubuntu1604.vagrant.cfg<wait> ",
                 "<enter>"
             ],
-            "disk_size": 196608,
+            "disk_size": 256000,
             "disk_type_id": "0",
             "cpus": 4,
             "memory": 2048,

--- a/lineage-vmware.json
+++ b/lineage-vmware.json
@@ -44,17 +44,6 @@
             ]
         },
         {
-            "type": "file",
-            "direction": "upload",
-            "source": "res/blobs/system-blobs.tar.gz",
-            "destination": "/home/vagrant/system-blobs.tar.gz",
-            "only": [
-                "lineage-vmware",
-                "lineage-nash-vmware"
-
-            ]
-        },
-        {
             "scripts": [
                 "scripts/ubuntu1604/lineage.sh"
             ],

--- a/scripts/ubuntu1604/lineage.sh
+++ b/scripts/ubuntu1604/lineage.sh
@@ -427,7 +427,7 @@ echo
 echo NAME=\$NAME
 echo EMAIL=\$EMAIL
 echo
-echo "Override the above environment variables in your Vagrantfile to alter the build configuration."
+echo "Override the above environment variables to alter the build configuration."
 echo
 echo
 sleep 10
@@ -535,4 +535,14 @@ chown vagrant:vagrant /home/vagrant/lineage-build.sh
 chmod +x /home/vagrant/lineage-build.sh
 
 # Customize the message of the day
-printf "\nLineage Development Environment\nTo download and compile Lineage, just execute the lineage-build.sh script.\n\n" > /etc/motd
+cat <<-EOF > /etc/motd
+Lineage Development Environment
+To download and compile Lineage, just execute the lineage-build.sh script:
+
+  # Build LineageOS 14.1 for the Motorola Photon Q
+  DEVICE=xt897 BRANCH=cm-14.1 VENDOR=motorola ./lineage-build.sh
+
+  # Build LineageOS 15.1 for the Motorola Z2 Force
+  DEVICE=nash BRANCH=lineage-15.1 VENDOR=motorola ./lineage-build.sh
+
+EOF

--- a/scripts/ubuntu1604/lineage.sh
+++ b/scripts/ubuntu1604/lineage.sh
@@ -513,7 +513,7 @@ MD5IMAGESUM="\$SYSIMAGE.md5sum"
 if [ -f "\$MD5IMAGESUM" ]; then
   (cd "\$DIRIMAGE" && md5sum -c "\$MD5IMAGESUM") || ( printf "\n\n\nThe MD5 hash failed to validate.\n\n\n"; exit 1 )
 else
-  (cd "\$DIRIMAGE" && md5sum "\$SYSIMAGESUM" > "\$MD5IMAGESUM")
+  (cd "\$DIRIMAGE" && md5sum "\$SYSIMAGE" > "\$MD5IMAGESUM")
 fi
 
 # Verify a sha256sum, or generate it.
@@ -521,7 +521,7 @@ SHAIMAGESUM="\$SYSIMAGE.sha256sum"
 if [ -f "\$SHAIMAGESUM" ]; then
   (cd "\$DIRIMAGE" && sha256sum -c "\$SHAIMAGESUM") || ( printf "\n\n\nThe SHA256 hash failed to validate.\n\n\n"; exit 1 )
 else
-  (cd "\$DIRIMAGE" && sha256sum "\$SYSIMAGESUM" > "\$SHAIMAGESUM")
+  (cd "\$DIRIMAGE" && sha256sum "\$SYSIMAGE" > "\$SHAIMAGESUM")
 fi
 
 # See what the output directory holds.

--- a/scripts/ubuntu1604/lineage.sh
+++ b/scripts/ubuntu1604/lineage.sh
@@ -491,7 +491,7 @@ git config --global user.email "\$EMAIL"
 git config --global color.ui false
 
 # Initialize the repo.
-repo init -u https://github.com/LineageOS/android.git -b \$BRANCH
+repo init -u https://github.com/LineageOS/android.git -b \$BRANCH -g default,-darwin
 
 # Set up the blob source.
 mkdir -p .repo/local_manifests

--- a/scripts/ubuntu1604/lineage.sh
+++ b/scripts/ubuntu1604/lineage.sh
@@ -548,7 +548,7 @@ SYSIMAGE="\$DIRIMAGE/\$VERSION_NAME-\$BUILDSTAMP-UNOFFICIAL-\$DEVICE.zip"
 SYSIMAGESUM="\$SYSIMAGE.md5sum"
 
 # Verify the image checksum.
-md5sum -c "\$SYSIMAGESUM" || ( printf "\n\n\nChecksum generation failed.\n\n\n"; exit 1 )
+(cd "\$DIRIMAGE" && md5sum -c "\$SYSIMAGESUM") || ( printf "\n\n\nChecksum generation failed.\n\n\n"; exit 1 )
 
 # See what the output directory holds.
 ls -alh "\$SYSIMAGE" "\$SYSIMAGESUM"

--- a/scripts/ubuntu1604/lineage.sh
+++ b/scripts/ubuntu1604/lineage.sh
@@ -423,7 +423,7 @@ export USE_CCACHE=1
 export CCACHE_DIR="\$HOME/cache"
 export CCACHE_COMPRESS=1
 export TMPDIR="\$HOME/temp"
-export PROCESSOR_COUNT=\`cat /proc/cpuinfo | grep processor | wc -l\`
+export PROCESSOR_COUNT=\$(nproc)
 
 # Jack is the Java compiler used by LineageOS 14.1+, and it is memory hungry.
 # We specify a memory limit of 8gb to avoid 'out of memory' errors.

--- a/scripts/ubuntu1604/lineage.sh
+++ b/scripts/ubuntu1604/lineage.sh
@@ -393,17 +393,6 @@ usermod -a -G adbusers vagrant
 chmod 644 /etc/udev/rules.d/51-android.rules
 # chcon "system_u:object_r:udev_rules_t:s0" /etc/udev/rules.d/51-android.rules
 
-if [[ "$PACKER_BUILD_NAME" =~ ^(lineage|lineageos)-nash-(vmware|hyperv|libvirt|parallels|virtualbox)$ ]]; then
-cat <<-EOF > /home/vagrant/lineage-build.sh
-#!/bin/bash
-
-# Build Lineage for the Motorola Z2 Force by default.
-
-export DEVICE=\${DEVICE:="nash"}
-export BRANCH=\${BRANCH:="lineage-15.1"}
-export VENDOR=\${VENDOR:="motorola"}
-EOF
-else
 cat <<-EOF > /home/vagrant/lineage-build.sh
 #!/bin/bash
 
@@ -413,10 +402,7 @@ cat <<-EOF > /home/vagrant/lineage-build.sh
 export DEVICE=\${DEVICE:="xt897"}
 export BRANCH=\${BRANCH:="cm-14.1"}
 export VENDOR=\${VENDOR:="motorola"}
-EOF
-fi
 
-cat <<-EOF >> /home/vagrant/lineage-build.sh
 export NAME=\${NAME:="Ladar Levison"}
 export EMAIL=\${EMAIL:="ladar@lavabit.com"}
 

--- a/scripts/ubuntu1604/lineage.sh
+++ b/scripts/ubuntu1604/lineage.sh
@@ -507,13 +507,25 @@ fi
 
 DIRIMAGE="\$HOME/android/lineage/out/target/product/\$DEVICE"
 SYSIMAGE="\$DIRIMAGE/\$VERSION_NAME-\$BUILDSTAMP-UNOFFICIAL-\$DEVICE.zip"
-SYSIMAGESUM="\$SYSIMAGE.md5sum"
 
-# Verify the image checksum.
-(cd "\$DIRIMAGE" && md5sum -c "\$SYSIMAGESUM") || ( printf "\n\n\nChecksum generation failed.\n\n\n"; exit 1 )
+# Verify the md5sum if it exists, otherwise generate it.
+MD5IMAGESUM="\$SYSIMAGE.md5sum"
+if [ -f "\$MD5IMAGESUM" ]; then
+  (cd "\$DIRIMAGE" && md5sum -c "\$MD5IMAGESUM") || ( printf "\n\n\nThe MD5 hash failed to validate.\n\n\n"; exit 1 )
+else
+  (cd "\$DIRIMAGE" && md5sum "\$SYSIMAGESUM" > "\$MD5IMAGESUM")
+fi
+
+# Verify a sha256sum, or generate it.
+SHAIMAGESUM="\$SYSIMAGE.sha256sum"
+if [ -f "\$SHAIMAGESUM" ]; then
+  (cd "\$DIRIMAGE" && sha256sum -c "\$SHAIMAGESUM") || ( printf "\n\n\nThe SHA256 hash failed to validate.\n\n\n"; exit 1 )
+else
+  (cd "\$DIRIMAGE" && sha256sum "\$SYSIMAGESUM" > "\$SHAIMAGESUM")
+fi
 
 # See what the output directory holds.
-ls -alh "\$SYSIMAGE" "\$SYSIMAGESUM"
+ls -alh "\$SYSIMAGE" "\$MD5IMAGESUM" "\$SHAIMAGESUM"
 
 # Push the new system image to the device.
 # adb push "\$SYSIMAGE" /sdcard/

--- a/scripts/ubuntu1604/lineage.sh
+++ b/scripts/ubuntu1604/lineage.sh
@@ -72,6 +72,9 @@ update-java-alternatives -s java-1.7.0-openjdk-amd64
 # Delete the downloaded Java 7 packages.
 rm --force openjdk-7-jre_7u121-2.6.8-2_amd64.deb openjdk-7-jre-headless_7u121-2.6.8-2_amd64.deb openjdk-7-jdk_7u121-2.6.8-2_amd64.deb libjpeg62-turbo_1.5.1-2_amd64.deb
 
+# Reenable TLSv1 support for Java 8, since it is required for old versions of Jack.
+sed -i '/^jdk.tls.disabledAlgorithms=/s/TLSv1, TLSv1.1, //' /etc/java-8-openjdk/security/java.security
+
 # Download the Android tools.
 retry curl  --location --output platform-tools-latest-linux.zip https://dl.google.com/android/repository/platform-tools-latest-linux.zip
 

--- a/scripts/ubuntu1604/lineage.sh
+++ b/scripts/ubuntu1604/lineage.sh
@@ -46,7 +46,7 @@ printf "\nalias python='/usr/bin/python3.6'\n" >> /home/vagrant/.bash_aliases
 retry apt-get --assume-yes install vim vim-nox wget curl gnupg mlocate sysstat lsof pciutils usbutils
 
 # Install the build dependencies.
-retry apt-get --assume-yes install bc bison build-essential curl flex g++-multilib gcc-multilib git gnupg gperf imagemagick lib32ncurses5-dev lib32readline6-dev lib32z1-dev libesd0-dev liblz4-tool libncurses5-dev libsdl1.2-dev libssl-dev libwxgtk3.0-dev libxml2 libxml2-utils lzop pngcrush rsync schedtool squashfs-tools xsltproc zip zlib1g-dev ninja-build
+retry apt-get --assume-yes install bc bison build-essential curl flex g++-multilib gcc-multilib git gnupg gperf imagemagick lib32ncurses5-dev lib32readline6-dev lib32z1-dev libesd0-dev liblz4-tool libncurses5-dev libsdl1.2-dev libssl-dev libwxgtk3.0-dev libxml2 libxml2-utils lzop pngcrush rsync schedtool squashfs-tools xsltproc zip zlib1g-dev ninja-build ccache
 
 # Java 8 Support
 retry apt-get --assume-yes install openjdk-8-jdk openjdk-8-jdk-headless openjdk-8-jre openjdk-8-jre-headless icedtea-8-plugin
@@ -463,9 +463,8 @@ sleep 10
 
 # Setup the branch and enable the distributed cache.
 export USE_CCACHE=1
+export CCACHE_DIR="\$HOME/cache"
 export TMPDIR="\$HOME/temp"
-export ANDROID_CCACHE_SIZE="20G"
-export ANDROID_CCACHE_DIR="\$HOME/cache"
 export PROCESSOR_COUNT=`cat /proc/cpuinfo  | grep processor | wc -l`
 
 # Jack is the Java compiler used by LineageOS 14.1+, and it is memory hungry.
@@ -517,7 +516,14 @@ breakfast \$DEVICE || ( printf "\n\n\nBuild failed. (breakfast)\n\n\n"; exit 1 )
 
 # Setup the cache.
 cd \$HOME/android/lineage/
-prebuilts/misc/linux-x86/ccache/ccache -M 20G
+
+export CCACHE_EXEC="prebuilts/misc/linux-x86/ccache/ccache"
+
+if [ ! -x "\$CCACHE_EXEC" ]; then
+  export CCACHE_EXEC="\$(which ccache)"
+fi
+
+"\$CCACHE_EXEC" -M 20G
 
 # Start the build.
 croot

--- a/scripts/ubuntu1604/lineage.sh
+++ b/scripts/ubuntu1604/lineage.sh
@@ -72,35 +72,6 @@ update-java-alternatives -s java-1.7.0-openjdk-amd64
 # Delete the downloaded Java 7 packages.
 rm --force openjdk-7-jre_7u121-2.6.8-2_amd64.deb openjdk-7-jre-headless_7u121-2.6.8-2_amd64.deb openjdk-7-jdk_7u121-2.6.8-2_amd64.deb libjpeg62-turbo_1.5.1-2_amd64.deb
 
-# Enable the source code repositories.
-sed -i -e "s|.*deb-src |deb-src |g" /etc/apt/sources.list
-retry apt-get --assume-yes update
-
-# Ensure the dependencies required to compile git are available.
-retry apt-get --assume-yes install build-essential fakeroot dpkg-dev
-retry apt-get --assume-yes build-dep git
-
-# The build-dep command will remove the OpenSSL version of libcurl, so we have to
-# install here instead.
-retry apt-get --assume-yes install libcurl4-openssl-dev
-
-# Download the git sourcecode.
-mkdir -p $HOME/git-openssl && cd $HOME/git-openssl
-retry apt-get source git
-dpkg-source -x `find * -type f -name *.dsc`
-cd `find * -maxdepth 0 -type d`
-
-# Recompile git using OpenSSL instead of gnutls.
-sed -i -e "s|libcurl4-gnutls-dev|libcurl4-openssl-dev|g" debian/control
-sed -i -e "/TEST[ ]*=test/d" debian/rules
-dpkg-buildpackage -J4 -rfakeroot -b
-
-# Insall the new version.
-dpkg -i `find ../* -type f -name *amd64.deb`
-
-# Cleanup the git build directory.
-cd $HOME && rm --force --recursive $HOME/git-openssl
-
 # Download the Android tools.
 retry curl  --location --output platform-tools-latest-linux.zip https://dl.google.com/android/repository/platform-tools-latest-linux.zip
 

--- a/scripts/ubuntu1604/lineage.sh
+++ b/scripts/ubuntu1604/lineage.sh
@@ -503,7 +503,7 @@ cat <<-EOF2 > .repo/local_manifests/muppets-\$VENDOR.xml
 EOF2
 
 # Download the source code.
-repo --color=never sync --quiet --jobs=\${PROCESSOR_COUNT}
+repo --color=never sync --quiet --jobs=\${PROCESSOR_COUNT} -c --no-clone-bundle --no-tags
 
 # Setup the environment.
 source build/envsetup.sh

--- a/scripts/ubuntu1604/lineage.sh
+++ b/scripts/ubuntu1604/lineage.sh
@@ -530,11 +530,22 @@ croot
 brunch \$DEVICE || ( printf "\n\n\nBuild failed. (brunch)\n\n\n"; exit 1 )
 
 # Calculate the filename.
+VERSION_NAME="\$BRANCH"
+
+# A few select branches got rebranded
+if [[ "\$VERSION_NAME" =~ "cm-(11.0|13.0|14.1)" ]]; then
+  VERSION_NAME=\${VERSION_NAME/cm-/lineage-}
+fi
+
+# 11.0 was only designated as '11'
+if [[ "\$VERSION_NAME" =~ "lineage-11.0" ]]; then
+  VERSION_NAME="lineage-11"
+fi
+
 BUILDSTAMP=\`date --utc +'%Y%m%d'\`
 DIRIMAGE="\$HOME/android/lineage/out/target/product/\$DEVICE"
-SYSIMAGE="\$DIRIMAGE/lineage-14.1-\$BUILDSTAMP-UNOFFICIAL-\$DEVICE.zip"
-SYSIMAGESUM="\$DIRIMAGE/lineage-14.1-\$BUILDSTAMP-UNOFFICIAL-\$DEVICE.zip.md5sum"
-#RECIMAGE="lineage-\$BUILDVERSION-\$BUILDSTAMP-UNOFFICIAL-\$DEVICE-recovery.img"
+SYSIMAGE="\$DIRIMAGE/\$VERSION_NAME-\$BUILDSTAMP-UNOFFICIAL-\$DEVICE.zip"
+SYSIMAGESUM="\$SYSIMAGE.md5sum"
 
 # Verify the image checksum.
 md5sum -c "\$SYSIMAGESUM" || ( printf "\n\n\nChecksum generation failed.\n\n\n"; exit 1 )

--- a/scripts/ubuntu1604/lineage.sh
+++ b/scripts/ubuntu1604/lineage.sh
@@ -525,6 +525,8 @@ fi
 
 "\$CCACHE_EXEC" -M 20G
 
+BUILDSTAMP=\`date --utc +'%Y%m%d'\`
+
 # Start the build.
 croot
 brunch \$DEVICE || ( printf "\n\n\nBuild failed. (brunch)\n\n\n"; exit 1 )
@@ -542,7 +544,6 @@ if [[ "\$VERSION_NAME" =~ "lineage-11.0" ]]; then
   VERSION_NAME="lineage-11"
 fi
 
-BUILDSTAMP=\`date --utc +'%Y%m%d'\`
 DIRIMAGE="\$HOME/android/lineage/out/target/product/\$DEVICE"
 SYSIMAGE="\$DIRIMAGE/\$VERSION_NAME-\$BUILDSTAMP-UNOFFICIAL-\$DEVICE.zip"
 SYSIMAGESUM="\$SYSIMAGE.md5sum"

--- a/scripts/ubuntu1604/lineage.sh
+++ b/scripts/ubuntu1604/lineage.sh
@@ -423,7 +423,7 @@ export USE_CCACHE=1
 export CCACHE_DIR="\$HOME/cache"
 export CCACHE_COMPRESS=1
 export TMPDIR="\$HOME/temp"
-export PROCESSOR_COUNT=`cat /proc/cpuinfo  | grep processor | wc -l`
+export PROCESSOR_COUNT=\`cat /proc/cpuinfo | grep processor | wc -l\`
 
 # Jack is the Java compiler used by LineageOS 14.1+, and it is memory hungry.
 # We specify a memory limit of 8gb to avoid 'out of memory' errors.

--- a/scripts/ubuntu1604/lineage.sh
+++ b/scripts/ubuntu1604/lineage.sh
@@ -496,7 +496,7 @@ brunch \$DEVICE || ( printf "\n\n\nBuild failed. (brunch)\n\n\n"; exit 1 )
 VERSION_NAME="\$BRANCH"
 
 # A few select branches got rebranded
-if [[ "\$VERSION_NAME" =~ "cm-(11.0|13.0|14.1)" ]]; then
+if [[ "\$VERSION_NAME" =~ ^cm-(11\.0|13\.0|14\.1)$ ]]; then
   VERSION_NAME=\${VERSION_NAME/cm-/lineage-}
 fi
 

--- a/scripts/ubuntu1604/lineage.sh
+++ b/scripts/ubuntu1604/lineage.sh
@@ -394,7 +394,7 @@ chmod 644 /etc/udev/rules.d/51-android.rules
 # chcon "system_u:object_r:udev_rules_t:s0" /etc/udev/rules.d/51-android.rules
 
 cat <<-EOF > /home/vagrant/lineage-build.sh
-#!/bin/bash
+#!/bin/bash -e
 
 # Build Lineage for Motorol Photon Q by default - because physical keyboards eat virtual keyboards
 # for breakfast, brunch and then dinner.

--- a/scripts/ubuntu1604/lineage.sh
+++ b/scripts/ubuntu1604/lineage.sh
@@ -435,6 +435,7 @@ sleep 10
 # Setup the branch and enable the distributed cache.
 export USE_CCACHE=1
 export CCACHE_DIR="\$HOME/cache"
+export CCACHE_COMPRESS=1
 export TMPDIR="\$HOME/temp"
 export PROCESSOR_COUNT=`cat /proc/cpuinfo  | grep processor | wc -l`
 

--- a/scripts/ubuntu1604/network.sh
+++ b/scripts/ubuntu1604/network.sh
@@ -37,7 +37,7 @@ sysctl net.ipv6.conf.all.disable_ipv6=1
 printf "\nnet.ipv6.conf.all.disable_ipv6 = 1\n" >> /etc/sysctl.conf
 
 # Set the hostname, and then ensure it will resolve properly.
-if [[ "$PACKER_BUILD_NAME" =~ ^(lineage|lineageos)(-nash)?-(vmware|hyperv|libvirt|parallels|virtualbox)$ ]]; then
+if [[ "$PACKER_BUILD_NAME" =~ ^(lineage|lineageos)-(vmware|hyperv|libvirt|parallels|virtualbox)$ ]]; then
   printf "lineage.builder\n" > /etc/hostname
   printf "\n127.0.0.1 lineage.builder\n\n" >> /etc/hosts
 elif [[ "$PACKER_BUILD_NAME" =~ ^generic-ubuntu1604-(vmware|hyperv|libvirt|parallels|virtualbox)$ ]]; then

--- a/tpl/lineage.rb
+++ b/tpl/lineage.rb
@@ -19,13 +19,6 @@ Vagrant.configure("2") do |config|
 
   config.vm.usable_port_range = 20000..30000
 
-  # The box ships with a short script that will clone the git repos and
-  # compile the code. This line will trigger that process automatically
-  # when the box is provisioned.
-  config.vm.provision "shell", run: "always", inline: <<-SHELL
-    su -l vagrant -c '/home/vagrant/lineage-build.sh'
-  SHELL
-
   # Lineage will build and run comfortably with 1 CPU and 512MB of RAM
   # but adding a second CPU and increasing the RAM to 2048MB will speed
   # things up considerably during the build process.

--- a/tpl/lineageos.rb
+++ b/tpl/lineageos.rb
@@ -19,13 +19,6 @@ Vagrant.configure("2") do |config|
 
   config.vm.usable_port_range = 20000..30000
 
-  # The box ships with a short script that will clone the git repos and
-  # compile the code. This line will trigger that process automatically
-  # when the box is provisioned.
-  config.vm.provision "shell", run: "always", inline: <<-SHELL
-    su -l vagrant -c '/home/vagrant/lineage-build.sh'
-  SHELL
-
   # Lineage will build and run comfortably with 1 CPU and 512MB of RAM
   # but adding a second CPU and increasing the RAM to 2048MB will speed
   # things up considerably during the build process.


### PR DESCRIPTION
- Fix the blobs situation
- Make LineageOS 18.1 build
- Fix ccache for everything that doesn't have a ccache prebuilt
- Fix after-build commands for everything that is not LineageOS 14.1
- Optimized download size and storage usage a bit
- Remove custom-built git package
- Compress ccache by default
- Remove the nash box variant
- Move the lineage-build.sh line from provisioning script to motd