### PR TITLE
Some more fixes for the Lineage fixes

### DIFF
--- a/scripts/ubuntu1604/lineage.sh
+++ b/scripts/ubuntu1604/lineage.sh
@@ -587,7 +587,7 @@ cat <<-EOF > /etc/motd
   
   # To build versions of LineageOS versions between 11.0 and 13.0, enable Java 7, 
   # for LineageOS 13.0 on the Sony Xperia T, use the following.
-  env VENDOR=sony DEVICE=mint BRANCH=lineage-13.0 USE_JAVA7=true ./lineage-build.sh
+  env VENDOR=sony DEVICE=mint BRANCH=cm-13.0 USE_JAVA7=true ./lineage-build.sh
 
   # Finally, to build LineageOS for devices without official support, or to 
   # simply override the default repository configuration, create a 

--- a/scripts/ubuntu1604/lineage.sh
+++ b/scripts/ubuntu1604/lineage.sh
@@ -482,8 +482,14 @@ END
 fi
 
 # Download the source code.
+# --current-branch:  Ensure that we only fetch the needed branches from the server.
+# --no-clone-bundle: Disables use of clone.bundle, which either sends useless requests to hosts
+#                    that do not support that feature or downloads much more data than actually
+#                    needed to get a working tree.
+# --no-tags:         Ensure that we don't fetch tags that are not needed, as that will indirectly
+#                    pull in most branches again.
 let JOBS=\${PROCESSOR_COUNT}*2
-repo --color=never sync --quiet --jobs=\${JOBS}
+repo --color=never sync --quiet --jobs=\${JOBS} --current-branch --no-clone-bundle --no-tags
 
 # Setup the environment.
 source build/envsetup.sh

--- a/scripts/ubuntu1604/lineage.sh
+++ b/scripts/ubuntu1604/lineage.sh
@@ -418,7 +418,7 @@ export BRANCH=\${BRANCH:="lineage-18.1"}
 export VENDOR=\${VENDOR:="fxtec"}
 
 export NAME=\${NAME:="Robox Build Robot"}
-export EMAIL=\${EMAIL:="robot@lineageos.org"}
+export EMAIL=\${EMAIL:="robot@lavabit.com"}
 
 echo DEVICE=\$DEVICE
 echo BRANCH=\$BRANCH


### PR DESCRIPTION
The sync options specifically cut off around 10GB of disk usage for a normal LineageOS 18.1 build tree.