### PR TITLE
correct Ubuntu 22.04 ISO urls

### DIFF
--- a/generic-hyperv.json
+++ b/generic-hyperv.json
@@ -5532,7 +5532,7 @@
       "memory": 2048,
       "cpus": 2,
       "http_directory": "http",
-      "iso_url": "https://mirrors.kernel.org/ubuntu-releases/21.10/ubuntu-21.10-live-server-amd64.iso",
+      "iso_url": "https://releases.ubuntu.com/22.04/ubuntu-22.04-live-server-amd64.iso",
       "iso_checksum": "sha256:84aeaf7823c8c61baa0ae862d0a06b03409394800000b3235854a6b38eb4856f",
       "ssh_username": "root",
       "ssh_password": "vagrant",

--- a/generic-libvirt.json
+++ b/generic-libvirt.json
@@ -5569,7 +5569,7 @@
       "memory": 2048,
       "http_directory": "http",
       "headless": true,
-      "iso_url": "https://mirrors.kernel.org/ubuntu-releases/21.10/ubuntu-21.10-live-server-amd64.iso",
+      "iso_url": "https://releases.ubuntu.com/22.04/ubuntu-22.04-live-server-amd64.iso",
       "iso_checksum": "sha256:84aeaf7823c8c61baa0ae862d0a06b03409394800000b3235854a6b38eb4856f",
       "ssh_username": "root",
       "ssh_password": "vagrant",

--- a/generic-parallels.json
+++ b/generic-parallels.json
@@ -7548,7 +7548,7 @@
       "guest_os_type": "ubuntu",
       "skip_compaction": false,
       "http_directory": "http",
-      "iso_url": "https://mirrors.kernel.org/ubuntu-releases/21.10/ubuntu-21.10-live-server-amd64.iso",
+      "iso_url": "https://releases.ubuntu.com/22.04/ubuntu-22.04-live-server-amd64.iso",
       "iso_checksum": "sha256:84aeaf7823c8c61baa0ae862d0a06b03409394800000b3235854a6b38eb4856f",
       "ssh_username": "root",
       "ssh_password": "vagrant",

--- a/generic-virtualbox.json
+++ b/generic-virtualbox.json
@@ -6131,7 +6131,7 @@
       "vrdp_bind_address": "127.0.0.1",
       "vrdp_port_min": 11000,
       "vrdp_port_max": 12000,
-      "iso_url": "https://mirrors.kernel.org/ubuntu-releases/21.10/ubuntu-21.10-live-server-amd64.iso",
+      "iso_url": "https://releases.ubuntu.com/22.04/ubuntu-22.04-live-server-amd64.iso",
       "iso_checksum": "sha256:84aeaf7823c8c61baa0ae862d0a06b03409394800000b3235854a6b38eb4856f",
       "ssh_username": "root",
       "ssh_password": "vagrant",

--- a/generic-vmware.json
+++ b/generic-vmware.json
@@ -6130,7 +6130,7 @@
       "vnc_disable_password": true,
       "vnc_bind_address": "127.0.0.1",
       "vmx_remove_ethernet_interfaces": true,
-      "iso_url": "https://mirrors.kernel.org/ubuntu-releases/21.10/ubuntu-21.10-live-server-amd64.iso",
+      "iso_url": "https://releases.ubuntu.com/22.04/ubuntu-22.04-live-server-amd64.iso",
       "iso_checksum": "sha256:84aeaf7823c8c61baa0ae862d0a06b03409394800000b3235854a6b38eb4856f",
       "ssh_username": "root",
       "ssh_password": "vagrant",

--- a/packer-cache.json
+++ b/packer-cache.json
@@ -1158,7 +1158,7 @@
     {
       "name": "ubuntu2204",
       "output_directory": "output/ubuntu2204",
-      "iso_url": "https://mirrors.kernel.org/ubuntu-releases/21.10/ubuntu-21.10-live-server-amd64.iso",
+      "iso_url": "https://releases.ubuntu.com/22.04/ubuntu-22.04-live-server-amd64.iso",
       "iso_checksum": "sha256:84aeaf7823c8c61baa0ae862d0a06b03409394800000b3235854a6b38eb4856f",
       "boot_wait": "5s",
       "disk_size": 1,


### PR DESCRIPTION
- use 22.04, not 21.10 ISOs
- use release.ubuntu.com, kernel.org doesn't seem to have these (yet?)