### PR TITLE
remove snapd on ubuntu 2204

### DIFF
--- a/scripts/ubuntu2204/cleanup.sh
+++ b/scripts/ubuntu2204/cleanup.sh
@@ -26,6 +26,9 @@ dpkg -l eatmydata &>/dev/null && apt-get --assume-yes purge eatmydata
 dpkg -l libeatmydata1 &>/dev/null && apt-get --assume-yes purge libeatmydata1
 dpkg -l cloud-init &>/dev/null && apt-get --assume-yes purge cloud-init
 
+# Remove snapd packages
+dpkg -l snapd &>/dev/null && apt-get --assume-yes purge snapd
+
 # We can probably also remove unattended-upgrades ... but we'll save that for later.
 # dpkg -l unattended-upgrades &>/dev/null && apt-get --assume-yes purge unattended-upgrades
 


### PR DESCRIPTION
snapd appears to be enabled by default on ubuntu 22.04, as discussed in #238 