### PR TITLE
Revert "debian11-x32: Force enable IO-APIC"

### DIFF
--- a/generic-virtualbox-x32.json
+++ b/generic-virtualbox-x32.json
@@ -388,9 +388,7 @@
           "modifyvm",
           "{{.Name}}",
           "--vram",
-          "64",
-          "--ioapic",
-          "on"
+          "64"
         ]
       ],
       "hard_drive_interface": "sata",
@@ -444,9 +442,7 @@
           "modifyvm",
           "{{.Name}}",
           "--vram",
-          "64",
-          "--ioapic",
-          "on"
+          "64"
         ]
       ],
       "hard_drive_interface": "sata",


### PR DESCRIPTION
This has since been fixed in the upstream VirtualBox plugin.

This reverts commit 87e34572948dd082fc04d50f26da7976d37720ad.